### PR TITLE
Fix another problem in find_peaks()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.11-1
-Date: 2018-01-11
+Version: 0.11-2
+Date: 2018-01-12
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.10
-Date: 2018-01-09
+Version: 0.11-1
+Date: 2018-01-11
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## qtl2 0.11-1 (2018-01-11)
+
+### Bug fixes
+
+- Further embarassment: the bug fix in version 0.10 didn't fully fix
+  the problem.
+
+
 ## qtl2 0.10 (2018-01-09)
 
 ### Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-## qtl2 0.11-1 (2018-01-11)
+## qtl2 0.11-2 (2018-01-12)
+
+### New features
+
+- `find_peaks()` and `max_scan1()` can now take snpinfo tables (as
+  produced by `index_snps()` and `scan1snps()`) in place of the map.
 
 ### Bug fixes
 

--- a/R/find_peaks.R
+++ b/R/find_peaks.R
@@ -8,7 +8,8 @@
 #' @param scan1_output An object of class `"scan1"` as returned by
 #' [scan1()].
 #' @param map A list of vectors of marker positions, as produced by
-#' [insert_pseudomarkers()].
+#' [insert_pseudomarkers()]. Can also be an indexed SNP info table,
+#' as from [index_snps()] or [scan1snps()].
 #' @param threshold Minimum LOD score for a peak (can be a vector with
 #' separate thresholds for each lod score column in
 #' `scan1_output`)
@@ -114,6 +115,11 @@ find_peaks <-
              expand2markers=TRUE, sort_by=c("column", "pos", "lod"), cores=1)
 {
     sort_by <- match.arg(sort_by)
+
+    # check if map input is a snpinfo table; if so convert to
+    if(is.data.frame(map) && "index" %in% names(map)) { # looks like snpinfo table
+        map <- snpinfo_to_map(map)
+    }
 
     # align scan1_output and map
     tmp <- align_scan1_map(scan1_output, map)

--- a/R/find_peaks_and_bayesint.R
+++ b/R/find_peaks_and_bayesint.R
@@ -106,7 +106,17 @@ find_peaks_and_bayesint <-
         peaks <- cluster_lapply(cores, batch_index, by_batch_func)
     }
 
-    result <- NULL
+    # empty data frame to start
+    result <- data.frame(lodindex=numeric(0),
+                         lodcolumn=character(0),
+                         chr=character(0),
+                         pos=numeric(0),
+                         lod=numeric(0),
+                         ci_lo=numeric(0),
+                         ci_hi=numeric(0),
+                         row.names=character(0),
+                         stringsAsFactors=FALSE)
+
     for(p in peaks) result <- rbind(result, p)
 
     rownames(result) <- NULL

--- a/R/find_peaks_and_lodint.R
+++ b/R/find_peaks_and_lodint.R
@@ -109,7 +109,17 @@ find_peaks_and_lodint <-
         peaks <- cluster_lapply(cores, batch_index, by_batch_func)
     }
 
-    result <- NULL
+    # empty data frame to start
+    result <- data.frame(lodindex=numeric(0),
+                         lodcolumn=character(0),
+                         chr=character(0),
+                         pos=numeric(0),
+                         lod=numeric(0),
+                         ci_lo=numeric(0),
+                         ci_hi=numeric(0),
+                         row.names=character(0),
+                         stringsAsFactors=FALSE)
+
     for(p in peaks) result <- rbind(result, p)
 
     rownames(result) <- NULL

--- a/R/max_scan1.R
+++ b/R/max_scan1.R
@@ -57,10 +57,6 @@ max_scan1 <-
 {
     if(is.null(scan1_output)) stop("scan1_output is NULL")
 
-    if(is.data.frame(map) && "index" %in% names(map)) { # looks like snpinfo table
-        map <- snpinfo_to_map(map)
-    }
-
     if(length(lodcolumn) == 0) stop("lodcolumn has length 0")
     if(length(lodcolumn) > 1) {
         lodcolumn <- lodcolumn[1]
@@ -78,6 +74,10 @@ max_scan1 <-
     if(missing(map) || is.null(map)) {
         warning("map not provided; returning the genome-wide max () LOD but not its position")
         return( setNames( max(scan1_output[,lodcolumn], na.rm=TRUE), colnames(scan1_output)[lodcolumn]) )
+    }
+
+    if(is.data.frame(map) && "index" %in% names(map)) { # looks like snpinfo table
+        map <- snpinfo_to_map(map)
     }
 
     # align scan1_output and map

--- a/R/max_scan1.R
+++ b/R/max_scan1.R
@@ -10,7 +10,8 @@
 #' @param scan1_output An object of class `"scan1"` as returned by
 #' [scan1()].
 #' @param map A list of vectors of marker positions, as produced by
-#' [insert_pseudomarkers()].
+#' [insert_pseudomarkers()]. Can also be an indexed SNP info table,
+#' as from [index_snps()] or [scan1snps()].
 #' @param lodcolumn An integer or character string indicating the LOD
 #' score column, either as a numeric index or column name.
 #' @param chr Option vector of chromosomes to consider.
@@ -55,6 +56,10 @@ max_scan1 <-
     function(scan1_output, map, lodcolumn=1, chr=NULL, na.rm=TRUE, ...)
 {
     if(is.null(scan1_output)) stop("scan1_output is NULL")
+
+    if(is.data.frame(map) && "index" %in% names(map)) { # looks like snpinfo table
+        map <- snpinfo_to_map(map)
+    }
 
     if(length(lodcolumn) == 0) stop("lodcolumn has length 0")
     if(length(lodcolumn) > 1) {

--- a/man/find_peaks.Rd
+++ b/man/find_peaks.Rd
@@ -14,7 +14,8 @@ find_peaks(scan1_output, map, threshold = 3, peakdrop = Inf, drop = NULL,
 \code{\link[=scan1]{scan1()}}.}
 
 \item{map}{A list of vectors of marker positions, as produced by
-\code{\link[=insert_pseudomarkers]{insert_pseudomarkers()}}.}
+\code{\link[=insert_pseudomarkers]{insert_pseudomarkers()}}. Can also be an indexed SNP info table,
+as from \code{\link[=index_snps]{index_snps()}} or \code{\link[=scan1snps]{scan1snps()}}.}
 
 \item{threshold}{Minimum LOD score for a peak (can be a vector with
 separate thresholds for each lod score column in

--- a/man/max_scan1.Rd
+++ b/man/max_scan1.Rd
@@ -15,7 +15,8 @@ max_scan1(scan1_output, map, lodcolumn = 1, chr = NULL, na.rm = TRUE, ...)
 \code{\link[=scan1]{scan1()}}.}
 
 \item{map}{A list of vectors of marker positions, as produced by
-\code{\link[=insert_pseudomarkers]{insert_pseudomarkers()}}.}
+\code{\link[=insert_pseudomarkers]{insert_pseudomarkers()}}. Can also be an indexed SNP info table,
+as from \code{\link[=index_snps]{index_snps()}} or \code{\link[=scan1snps]{scan1snps()}}.}
 
 \item{lodcolumn}{An integer or character string indicating the LOD
 score column, either as a numeric index or column name.}

--- a/tests/testthat/test-find_peaks.R
+++ b/tests/testthat/test-find_peaks.R
@@ -142,6 +142,22 @@ test_that("find_peaks works", {
 
     expect_equal( find_peaks(out, map, threshold=9999), blank_output)
 
+    # test that find_peaks works if there are no peaks above threshold
+    # like above, but also requesting LOD or Bayes intervals
+    blank_output <- structure(list(lodindex = numeric(0),
+                                   lodcolumn = character(0),
+                                   chr = structure(integer(0), .Label = c("1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+                                                                          "11", "12", "13", "14", "15", "16", "17", "18", "19", "X"),
+                                                   class = "factor"),
+                                   pos = numeric(0),
+                                   lod = numeric(0),
+                                   ci_lo = numeric(0),
+                                   ci_hi = numeric(0)),
+                              .Names = c("lodindex", "lodcolumn", "chr", "pos", "lod", "ci_lo", "ci_hi"),
+                              row.names = integer(0), class = "data.frame")
+
+    expect_equal( find_peaks(out, map, threshold=9999, drop=2), blank_output)
+    expect_equal( find_peaks(out, map, threshold=9999, prob=0.95), blank_output)
 
 })
 


### PR DESCRIPTION
- Fix another problem in `find_peaks()`. It's really the same problem as PR #26, but I didn't catch the cases with LOD support or Bayes credible intervals. This is Issue #30.

- Also extend `find_peaks()` for use with snpinfo tables. Do the same with `max_scan1()`. This is Issue #28.