### PR TITLE
Release version 0.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2
-Version: 0.11-3
+Version: 0.12
 Date: 2018-01-19
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.11-2
-Date: 2018-01-12
+Version: 0.11-3
+Date: 2018-01-19
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,14 @@
-## qtl2 0.11-2 (2018-01-12)
+## qtl2 0.11-3 (2018-01-19)
 
 ### New features
 
 - `find_peaks()` and `max_scan1()` can now take snpinfo tables (as
   produced by `index_snps()` and `scan1snps()`) in place of the map.
+
+### Minor changes
+
+- Sped up a bunch of the examples in the help files (mostly by
+  subsetting the example datasets).
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2 0.11-3 (2018-01-19)
+## qtl2 0.12 (2018-01-19)
 
 ### New features
 
@@ -13,7 +13,7 @@
 ### Bug fixes
 
 - Further embarassment: the bug fix in version 0.10 didn't fully fix
-  the problem.
+  the problem with `find_peaks()`.
 
 
 ## qtl2 0.10 (2018-01-09)

--- a/R/calc_entropy.R
+++ b/R/calc_entropy.R
@@ -23,7 +23,7 @@
 #'
 #' @examples
 #' grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2"))
-#' \dontshow{grav2 <- grav2[,3] # subset to chr 3}
+#' \dontshow{grav2 <- grav2[,c(4,5)] # subset to chr 3}
 #' probs <- calc_genoprob(grav2, error_prob=0.002)
 #' e <- calc_entropy(probs)
 #' e <- do.call("cbind", e) # combine chromosomes into one big matrix

--- a/R/calc_entropy.R
+++ b/R/calc_entropy.R
@@ -29,10 +29,10 @@
 #' e <- do.call("cbind", e) # combine chromosomes into one big matrix
 #'
 #' # summarize by individual
-#' hist(rowMeans(e), breaks=25, main="Ave entropy by individual", xlab="Entropy")
+#' mean_ind <- rowMeans(e)
 #'
 #' # summarize by marker
-#' plot(colMeans(e), xlab="marker index", ylab="Average entropy")
+#' mean_marker <- colMeans(e)
 calc_entropy <-
     function(probs, quiet=TRUE, cores=1)
 {

--- a/R/calc_entropy.R
+++ b/R/calc_entropy.R
@@ -23,6 +23,7 @@
 #'
 #' @examples
 #' grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2"))
+#' \dontshow{grav2 <- grav2[,3] # subset to chr 3}
 #' probs <- calc_genoprob(grav2, error_prob=0.002)
 #' e <- calc_entropy(probs)
 #' e <- do.call("cbind", e) # combine chromosomes into one big matrix

--- a/R/count_xo.R
+++ b/R/count_xo.R
@@ -19,13 +19,13 @@
 #'
 #' @examples
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[1:20,1:2] # subset to first 20 individuals and to chr 1 and 2}
 #' map <- insert_pseudomarkers(iron$gmap, step=1)
 #' pr <- calc_genoprob(iron, map, error_prob=0.002, map_function="c-f")
 #' g <- maxmarg(pr)
 #' n_xo <- count_xo(g)
 #'
 #' # imputations
-#' \dontshow{iron <- iron[1:20,1:2]}
 #' imp <- sim_geno(iron, map, error_prob=0.002, map_function="c-f", n_draws=32)
 #' n_xo_imp <- count_xo(imp)
 #' # sums across chromosomes

--- a/R/decomp_kinship.R
+++ b/R/decomp_kinship.R
@@ -18,6 +18,7 @@
 #'
 #' @examples
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[1:30,18:19] # subset to 30 individuals and two chromosomes}
 #' map <- insert_pseudomarkers(iron$gmap, step=1)
 #' probs <- calc_genoprob(iron, map, error_prob=0.002)
 #' K <- calc_kinship(probs)

--- a/R/est_herit.R
+++ b/R/est_herit.R
@@ -40,6 +40,7 @@
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,c("19","X")] # subset to two chromosomes}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/R/est_map.R
+++ b/R/est_map.R
@@ -41,6 +41,7 @@
 #'
 #' @examples
 #' grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2"))
+#' \dontshow{grav2 <- grav2[,"3"]}
 #' gmap <- est_map(grav2, error_prob=0.002)
 
 est_map <-

--- a/R/find_peaks.R
+++ b/R/find_peaks.R
@@ -82,6 +82,7 @@
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,c(1,2,7,8,9,13,15,16,19)]}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)
@@ -99,16 +100,16 @@
 #' out <- scan1(probs, pheno, addcovar=covar, Xcovar=Xcovar)
 #'
 #' # find just the highest peak on each chromosome
-#' find_peaks(out, map, threshold=3, peakdrop=Inf)
+#' find_peaks(out, map, threshold=3)
 #'
 #' # possibly multiple peaks per chromosome
-#' find_peaks(out, map, threshold=3, peakdrop=2)
+#' find_peaks(out, map, threshold=3, peakdrop=1)
 #'
-#' # possibly multiple peaks, also getting LOD support intervals
-#' find_peaks(out, map, threshold=3, peakdrop=2, drop=1.5)
+#' # possibly multiple peaks, also getting 1-LOD support intervals
+#' find_peaks(out, map, threshold=3, peakdrop=1, drop=1)
 #'
-#' # possibly multiple peaks, also getting Bayes intervals
-#' find_peaks(out, map, threshold=3, peakdrop=2, prob=0.95)
+#' # possibly multiple peaks, also getting 90% Bayes intervals
+#' find_peaks(out, map, threshold=3, peakdrop=1, prob=0.9)
 find_peaks <-
     function(scan1_output, map, threshold=3, peakdrop=Inf, drop=NULL, prob=NULL,
              thresholdX=NULL, peakdropX=NULL, dropX=NULL, probX=NULL,

--- a/R/fit1.R
+++ b/R/fit1.R
@@ -66,6 +66,7 @@
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,1:7] # subset to chr 1-7}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/R/plot_peaks.R
+++ b/R/plot_peaks.R
@@ -34,6 +34,7 @@
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,c(1,2,7,8,9,13,15,16,19)]}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/R/plot_pxg.R
+++ b/R/plot_pxg.R
@@ -44,6 +44,7 @@
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,"16"]}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/R/plot_snpasso.R
+++ b/R/plot_snpasso.R
@@ -76,16 +76,13 @@
 #' pr <- calc_genoprob(DOex, error_prob=0.002)
 #' apr <- genoprob_to_alleleprob(pr)
 #'
-#' # download snp info from web
-#' tmpfile <- tempfile()
-#' file <- paste0("https://raw.githubusercontent.com/rqtl/",
-#'                "qtl2data/master/DOex/c2_snpinfo.rds")
-#' download.file(file, tmpfile, quiet=TRUE)
-#' snpinfo <- readRDS(tmpfile)
-#' unlink(tmpfile)
+#' # query function for grabbing info about variants in region
+#' snp_dbfile <- system.file("extdata", "cc_variants_small.sqlite", package="qtl2")
+#' query_variants <- create_variant_query_func(snp_dbfile)
 #'
 #' # SNP association scan
-#' out_snps <- scan1snps(apr, DOex$pmap, DOex$pheno, snpinfo=snpinfo, keep_all_snps=TRUE)
+#' out_snps <- scan1snps(apr, DOex$pmap, DOex$pheno, query_func=query_variants,
+#'                       chr=2, start=97, end=98, keep_all_snps=TRUE)
 #'
 #' # plot results
 #' plot_snpasso(out_snps$lod, out_snps$snpinfo)
@@ -94,18 +91,15 @@
 #' plot(out_snps$lod, out_snps$snpinfo)
 #'
 #' # plot just subset of distinct SNPs
-#' plot_snpasso(out_snps$lod, out_snps$snpinfo, show_all_snps=FALSE)
+#' plot(out_snps$lod, out_snps$snpinfo, show_all_snps=FALSE)
 #'
 #' # highlight the top snps (with LOD within 1.5 of max)
 #' plot(out_snps$lod, out_snps$snpinfo, drop_hilit=1.5)
 #'
-#' # download gene info from web
-#' tmpfile <- tempfile()
-#' file <- paste0("https://raw.githubusercontent.com/rqtl/",
-#'                "qtl2data/master/DOex/c2_genes.rds")
-#' download.file(file, tmpfile, quiet=TRUE)
-#' genes <- readRDS(tmpfile)
-#' unlink(tmpfile)
+#' # query function for finding genes in region
+#' gene_dbfile <- system.file("extdata", "mouse_genes_small.sqlite", package="qtl2")
+#' query_genes <- create_gene_query_func(gene_dbfile)
+#' genes <- query_genes(2, 97, 98)
 #'
 #' # plot SNP association results with gene locations
 #' plot(out_snps$lod, out_snps$snpinfo, drop_hilit=1.5, genes=genes)

--- a/R/rcbind_scan1perm.R
+++ b/R/rcbind_scan1perm.R
@@ -20,6 +20,7 @@
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,c("19","X")] # subset to chr 19 and X}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)
@@ -167,6 +168,7 @@ c.scan1perm <- rbind.scan1perm
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,c("19","X")] # subset to chr 19 and X}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -95,6 +95,7 @@
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,c("19", "X")] # subset to chr 19 and X}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/R/scan1blup.R
+++ b/R/scan1blup.R
@@ -73,6 +73,7 @@
 #'
 #' # calculate genotype probabilities
 #' probs <- calc_genoprob(iron, map, error_prob=0.002)
+#' \dontshow{probs[["7"]] <- probs[["7"]][,,1:5] # reduce to very small number}
 #'
 #' # convert to allele probabilities
 #' aprobs <- genoprob_to_alleleprob(probs)
@@ -83,13 +84,13 @@
 #' names(covar) <- rownames(iron$covar)
 #'
 #' # calculate BLUPs of coefficients for chromosome 7
-#' blup <- scan1blup(aprobs[,7], pheno, addcovar=covar)
+#' blup <- scan1blup(aprobs[,"7"], pheno, addcovar=covar)
 #'
 #' # leave-one-chromosome-out kinship matrix for chr 7
-#' kinship7 <- calc_kinship(probs, "loco")[[7]]
+#' kinship7 <- calc_kinship(probs, "loco")[["7"]]
 #'
 #' # calculate BLUPs of coefficients for chromosome 7, adjusting for residual polygenic effect
-#' blup_pg <- scan1blup(aprobs[,7], pheno, kinship7, addcovar=covar)
+#' blup_pg <- scan1blup(aprobs[,"7"], pheno, kinship7, addcovar=covar)
 #'
 #' @export
 scan1blup <-

--- a/R/scan1coef.R
+++ b/R/scan1coef.R
@@ -79,6 +79,7 @@
 #'
 #' # calculate genotype probabilities
 #' probs <- calc_genoprob(iron, map, error_prob=0.002)
+#' \dontshow{probs[["7"]] <- probs[["7"]][,,1:5] # reduce to very small number}
 #'
 #' # grab phenotypes and covariates; ensure that covariates have names attribute
 #' pheno <- iron$pheno[,1]

--- a/R/summary_scan1perm.R
+++ b/R/summary_scan1perm.R
@@ -41,6 +41,7 @@
 #' @examples
 #' # read data
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+#' \dontshow{iron <- iron[,c(10,18,"X")]}
 #'
 #' # insert pseudomarkers into map
 #' map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/R/top_snps.R
+++ b/R/top_snps.R
@@ -51,34 +51,22 @@
 #' pr <- calc_genoprob(DOex, error_prob=0.002)
 #' apr <- genoprob_to_alleleprob(pr)
 #'
-#' # download snp info from web
-#' tmpfile <- tempfile()
-#' file <- paste0("https://raw.githubusercontent.com/rqtl/",
-#'                "qtl2data/master/DOex/c2_snpinfo.rds")
-#' download.file(file, tmpfile, quiet=TRUE)
-#' snpinfo <- readRDS(tmpfile)
-#' unlink(tmpfile)
+#' # query function for grabbing info about variants in region
+#' dbfile <- system.file("extdata", "cc_variants_small.sqlite", package="qtl2")
+#' query_variants <- create_variant_query_func(dbfile)
 #'
-#' # calculate strain distribution patterns
-#' snpinfo$sdp <- calc_sdp(snpinfo[,-(1:4)])
-#'
-#' # identify groups of equivalent SNPs
-#' snpinfo <- index_snps(DOex$pmap, snpinfo)
-#'
-#' # convert to snp probabilities
-#' snppr <- genoprob_to_snpprob(apr, snpinfo)
-#'
-#' # perform SNP association analysis (here, ignoring residual kinship)
-#' out_snps <- scan1(snppr, DOex$pheno)
+#' # SNP association scan, keep information on all SNPs
+#' out_snps <- scan1snps(apr, DOex$pmap, DOex$pheno, query_func=query_variants,
+#'                       chr=2, start=97, end=98, keep_all_snps=TRUE)
 #'
 #' # table with top SNPs
-#' top_snps(out_snps, snpinfo)
+#' top_snps(out_snps$lod, out_snps$snpinfo)
 #'
 #' # top SNPs among the distinct subset at which calculations were performed
-#' top_snps(out_snps, snpinfo, show_all_snps=FALSE)
+#' top_snps(out_snps$lod, out_snps$snpinfo, show_all_snps=FALSE)
 #'
 #' # top SNPs within 0.5 LOD of max
-#' top_snps(out_snps, snpinfo, 0.5)
+#' top_snps(out_snps$lod, out_snps$snpinfo, drop=0.5)
 #' }
 #' @export
 #' @seealso [index_snps()], [genoprob_to_snpprob()], [scan1snps()], [plot_snpasso()]

--- a/man/calc_entropy.Rd
+++ b/man/calc_entropy.Rd
@@ -30,7 +30,7 @@ We calculate -sum(p log_2 p), where we take 0 log 0 = 0.
 }
 \examples{
 grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2"))
-\dontshow{grav2 <- grav2[,3] # subset to chr 3}
+\dontshow{grav2 <- grav2[,c(4,5)] # subset to chr 3}
 probs <- calc_genoprob(grav2, error_prob=0.002)
 e <- calc_entropy(probs)
 e <- do.call("cbind", e) # combine chromosomes into one big matrix

--- a/man/calc_entropy.Rd
+++ b/man/calc_entropy.Rd
@@ -30,6 +30,7 @@ We calculate -sum(p log_2 p), where we take 0 log 0 = 0.
 }
 \examples{
 grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2"))
+\dontshow{grav2 <- grav2[,3] # subset to chr 3}
 probs <- calc_genoprob(grav2, error_prob=0.002)
 e <- calc_entropy(probs)
 e <- do.call("cbind", e) # combine chromosomes into one big matrix

--- a/man/calc_entropy.Rd
+++ b/man/calc_entropy.Rd
@@ -36,9 +36,9 @@ e <- calc_entropy(probs)
 e <- do.call("cbind", e) # combine chromosomes into one big matrix
 
 # summarize by individual
-hist(rowMeans(e), breaks=25, main="Ave entropy by individual", xlab="Entropy")
+mean_ind <- rowMeans(e)
 
 # summarize by marker
-plot(colMeans(e), xlab="marker index", ylab="Average entropy")
+mean_marker <- colMeans(e)
 }
 \keyword{utilities}

--- a/man/cbind.scan1perm.Rd
+++ b/man/cbind.scan1perm.Rd
@@ -30,6 +30,7 @@ and/or methods, to be used in parallel with
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,c("19","X")] # subset to chr 19 and X}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/man/count_xo.Rd
+++ b/man/count_xo.Rd
@@ -28,13 +28,13 @@ Estimate the numbers of crossovers in each individual on each chromosome.
 }
 \examples{
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[1:20,1:2] # subset to first 20 individuals and to chr 1 and 2}
 map <- insert_pseudomarkers(iron$gmap, step=1)
 pr <- calc_genoprob(iron, map, error_prob=0.002, map_function="c-f")
 g <- maxmarg(pr)
 n_xo <- count_xo(g)
 
 # imputations
-\dontshow{iron <- iron[1:20,1:2]}
 imp <- sim_geno(iron, map, error_prob=0.002, map_function="c-f", n_draws=32)
 n_xo_imp <- count_xo(imp)
 # sums across chromosomes

--- a/man/decomp_kinship.Rd
+++ b/man/decomp_kinship.Rd
@@ -27,6 +27,7 @@ The result contains an attribute \code{"eigen_decomp"}.
 }
 \examples{
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[1:30,18:19] # subset to 30 individuals and two chromosomes}
 map <- insert_pseudomarkers(iron$gmap, step=1)
 probs <- calc_genoprob(iron, map, error_prob=0.002)
 K <- calc_kinship(probs)

--- a/man/est_herit.Rd
+++ b/man/est_herit.Rd
@@ -52,6 +52,7 @@ explicitly.
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,c("19","X")] # subset to two chromosomes}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/man/est_map.Rd
+++ b/man/est_map.Rd
@@ -54,6 +54,7 @@ but a map function (by default, Haldane's) is used to derive the genetic distanc
 }
 \examples{
 grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2"))
+\dontshow{grav2 <- grav2[,"3"]}
 gmap <- est_map(grav2, error_prob=0.002)
 }
 \keyword{utilities}

--- a/man/find_peaks.Rd
+++ b/man/find_peaks.Rd
@@ -102,6 +102,7 @@ positions as the location of the peak.
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,c(1,2,7,8,9,13,15,16,19)]}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)
@@ -119,16 +120,16 @@ Xcovar <- get_x_covar(iron)
 out <- scan1(probs, pheno, addcovar=covar, Xcovar=Xcovar)
 
 # find just the highest peak on each chromosome
-find_peaks(out, map, threshold=3, peakdrop=Inf)
+find_peaks(out, map, threshold=3)
 
 # possibly multiple peaks per chromosome
-find_peaks(out, map, threshold=3, peakdrop=2)
+find_peaks(out, map, threshold=3, peakdrop=1)
 
-# possibly multiple peaks, also getting LOD support intervals
-find_peaks(out, map, threshold=3, peakdrop=2, drop=1.5)
+# possibly multiple peaks, also getting 1-LOD support intervals
+find_peaks(out, map, threshold=3, peakdrop=1, drop=1)
 
-# possibly multiple peaks, also getting Bayes intervals
-find_peaks(out, map, threshold=3, peakdrop=2, prob=0.95)
+# possibly multiple peaks, also getting 90\% Bayes intervals
+find_peaks(out, map, threshold=3, peakdrop=1, prob=0.9)
 }
 \seealso{
 \code{\link[=scan1]{scan1()}}, \code{\link[=lod_int]{lod_int()}}, \code{\link[=bayes_int]{bayes_int()}}

--- a/man/fit1.Rd
+++ b/man/fit1.Rd
@@ -84,6 +84,7 @@ QTL, and then taken as fixed as known in the genome scan.
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,1:7] # subset to chr 1-7}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/man/plot_peaks.Rd
+++ b/man/plot_peaks.Rd
@@ -43,6 +43,7 @@ cluttering the function definition.
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,c(1,2,7,8,9,13,15,16,19)]}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/man/plot_pxg.Rd
+++ b/man/plot_pxg.Rd
@@ -58,6 +58,7 @@ parameters in order to avoid cluttering the function definition.
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,"16"]}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/man/plot_snpasso.Rd
+++ b/man/plot_snpasso.Rd
@@ -89,16 +89,13 @@ DOex <- DOex[,"2"]
 pr <- calc_genoprob(DOex, error_prob=0.002)
 apr <- genoprob_to_alleleprob(pr)
 
-# download snp info from web
-tmpfile <- tempfile()
-file <- paste0("https://raw.githubusercontent.com/rqtl/",
-               "qtl2data/master/DOex/c2_snpinfo.rds")
-download.file(file, tmpfile, quiet=TRUE)
-snpinfo <- readRDS(tmpfile)
-unlink(tmpfile)
+# query function for grabbing info about variants in region
+snp_dbfile <- system.file("extdata", "cc_variants_small.sqlite", package="qtl2")
+query_variants <- create_variant_query_func(snp_dbfile)
 
 # SNP association scan
-out_snps <- scan1snps(apr, DOex$pmap, DOex$pheno, snpinfo=snpinfo, keep_all_snps=TRUE)
+out_snps <- scan1snps(apr, DOex$pmap, DOex$pheno, query_func=query_variants,
+                      chr=2, start=97, end=98, keep_all_snps=TRUE)
 
 # plot results
 plot_snpasso(out_snps$lod, out_snps$snpinfo)
@@ -107,18 +104,15 @@ plot_snpasso(out_snps$lod, out_snps$snpinfo)
 plot(out_snps$lod, out_snps$snpinfo)
 
 # plot just subset of distinct SNPs
-plot_snpasso(out_snps$lod, out_snps$snpinfo, show_all_snps=FALSE)
+plot(out_snps$lod, out_snps$snpinfo, show_all_snps=FALSE)
 
 # highlight the top snps (with LOD within 1.5 of max)
 plot(out_snps$lod, out_snps$snpinfo, drop_hilit=1.5)
 
-# download gene info from web
-tmpfile <- tempfile()
-file <- paste0("https://raw.githubusercontent.com/rqtl/",
-               "qtl2data/master/DOex/c2_genes.rds")
-download.file(file, tmpfile, quiet=TRUE)
-genes <- readRDS(tmpfile)
-unlink(tmpfile)
+# query function for finding genes in region
+gene_dbfile <- system.file("extdata", "mouse_genes_small.sqlite", package="qtl2")
+query_genes <- create_gene_query_func(gene_dbfile)
+genes <- query_genes(2, 97, 98)
 
 # plot SNP association results with gene locations
 plot(out_snps$lod, out_snps$snpinfo, drop_hilit=1.5, genes=genes)

--- a/man/rbind.scan1perm.Rd
+++ b/man/rbind.scan1perm.Rd
@@ -31,6 +31,7 @@ permutations are done on multiple processors in parallel.
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,c("19","X")] # subset to chr 19 and X}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/man/scan1.Rd
+++ b/man/scan1.Rd
@@ -108,6 +108,7 @@ in the results is a vector of heritabilities (one value for each phenotype). If
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,c("19", "X")] # subset to chr 19 and X}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/man/scan1blup.Rd
+++ b/man/scan1blup.Rd
@@ -84,6 +84,7 @@ map <- insert_pseudomarkers(iron$gmap, step=1)
 
 # calculate genotype probabilities
 probs <- calc_genoprob(iron, map, error_prob=0.002)
+\dontshow{probs[["7"]] <- probs[["7"]][,,1:5] # reduce to very small number}
 
 # convert to allele probabilities
 aprobs <- genoprob_to_alleleprob(probs)
@@ -94,13 +95,13 @@ covar <- match(iron$covar$sex, c("f", "m")) # make numeric
 names(covar) <- rownames(iron$covar)
 
 # calculate BLUPs of coefficients for chromosome 7
-blup <- scan1blup(aprobs[,7], pheno, addcovar=covar)
+blup <- scan1blup(aprobs[,"7"], pheno, addcovar=covar)
 
 # leave-one-chromosome-out kinship matrix for chr 7
-kinship7 <- calc_kinship(probs, "loco")[[7]]
+kinship7 <- calc_kinship(probs, "loco")[["7"]]
 
 # calculate BLUPs of coefficients for chromosome 7, adjusting for residual polygenic effect
-blup_pg <- scan1blup(aprobs[,7], pheno, kinship7, addcovar=covar)
+blup_pg <- scan1blup(aprobs[,"7"], pheno, kinship7, addcovar=covar)
 
 }
 \references{

--- a/man/scan1coef.Rd
+++ b/man/scan1coef.Rd
@@ -97,6 +97,7 @@ map <- insert_pseudomarkers(iron$gmap, step=1)
 
 # calculate genotype probabilities
 probs <- calc_genoprob(iron, map, error_prob=0.002)
+\dontshow{probs[["7"]] <- probs[["7"]][,,1:5] # reduce to very small number}
 
 # grab phenotypes and covariates; ensure that covariates have names attribute
 pheno <- iron$pheno[,1]

--- a/man/summary_scan1perm.Rd
+++ b/man/summary_scan1perm.Rd
@@ -48,6 +48,7 @@ significance level for the X chromosome.
 \examples{
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+\dontshow{iron <- iron[,c(10,18,"X")]}
 
 # insert pseudomarkers into map
 map <- insert_pseudomarkers(iron$gmap, step=1)

--- a/man/top_snps.Rd
+++ b/man/top_snps.Rd
@@ -60,34 +60,22 @@ DOex <- DOex[,"2"]
 pr <- calc_genoprob(DOex, error_prob=0.002)
 apr <- genoprob_to_alleleprob(pr)
 
-# download snp info from web
-tmpfile <- tempfile()
-file <- paste0("https://raw.githubusercontent.com/rqtl/",
-               "qtl2data/master/DOex/c2_snpinfo.rds")
-download.file(file, tmpfile, quiet=TRUE)
-snpinfo <- readRDS(tmpfile)
-unlink(tmpfile)
+# query function for grabbing info about variants in region
+dbfile <- system.file("extdata", "cc_variants_small.sqlite", package="qtl2")
+query_variants <- create_variant_query_func(dbfile)
 
-# calculate strain distribution patterns
-snpinfo$sdp <- calc_sdp(snpinfo[,-(1:4)])
-
-# identify groups of equivalent SNPs
-snpinfo <- index_snps(DOex$pmap, snpinfo)
-
-# convert to snp probabilities
-snppr <- genoprob_to_snpprob(apr, snpinfo)
-
-# perform SNP association analysis (here, ignoring residual kinship)
-out_snps <- scan1(snppr, DOex$pheno)
+# SNP association scan, keep information on all SNPs
+out_snps <- scan1snps(apr, DOex$pmap, DOex$pheno, query_func=query_variants,
+                      chr=2, start=97, end=98, keep_all_snps=TRUE)
 
 # table with top SNPs
-top_snps(out_snps, snpinfo)
+top_snps(out_snps$lod, out_snps$snpinfo)
 
 # top SNPs among the distinct subset at which calculations were performed
-top_snps(out_snps, snpinfo, show_all_snps=FALSE)
+top_snps(out_snps$lod, out_snps$snpinfo, show_all_snps=FALSE)
 
 # top SNPs within 0.5 LOD of max
-top_snps(out_snps, snpinfo, 0.5)
+top_snps(out_snps$lod, out_snps$snpinfo, drop=0.5)
 }
 }
 \seealso{


### PR DESCRIPTION
- Previously had fixed bug in `find_peaks()` and made both `find_peaks()` and `max_scan1()` work with snpinfo tables.
- Also, sped up a number of examples. Slowest now are `scan1blup()` and `calc_entropy()`, each about 1 sec.