### PR TITLE
max_scan1(): lodcolumn=NULL gives results for all columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.15-18
-Date: 2018-07-12
+Version: 0.15-19
+Date: 2018-07-14
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2 0.15-18 (2018-07-12)
+## qtl2 0.15-19 (2018-07-14)
 
 ### New features
 
@@ -54,6 +54,8 @@
 
 - Add `overwrite` argument (default `FALSE`) to `zip_datafiles()`,
   similar to that for `write_control_file()`.
+
+- `max_scan1()` no longer gives a warning if `map` is not provided.
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,11 @@
   in which case the SNP information for all SNPs with complete founder
   genotype data is calculated and used.
 
+- `max_scan1()` with `lodcolumn=NULL` returns the maximum for all
+  lod score columns. If `map` is included, the return value is in the
+  form returned by `find_peaks()`, namely with `lodindex` and
+  `lodcolumn` arguments added at the beginning.
+
 ### Minor changes
 
 - More informative error message in `est_herit()`, `scan1()`, etc.,

--- a/R/max_scan1.R
+++ b/R/max_scan1.R
@@ -231,6 +231,7 @@ maxall_scan1 <-
     function(scan1_output, map=NULL, chr=NULL, na.rm=TRUE, ...)
 {
     if(is.null(map)) {
+        warning("map not provided; returning the genome-wide maximum LODs but not their positions")
         if(!is.null(chr)) warning("chr ignored if map is not provided.")
 
         return(apply(scan1_output, 2, max, na.rm=na.rm))

--- a/R/max_scan1.R
+++ b/R/max_scan1.R
@@ -14,6 +14,7 @@
 #' as from [index_snps()] or [scan1snps()].
 #' @param lodcolumn An integer or character string indicating the LOD
 #' score column, either as a numeric index or column name.
+#' If `NULL`, return maximum for all columns.
 #' @param chr Option vector of chromosomes to consider.
 #' @param na.rm Ignored (take to be TRUE)
 #' @param ... Ignored
@@ -22,8 +23,11 @@
 #' @export
 #'
 #' @return If `map` is NULL, the genome-wide maximum LOD score for the selected column is returned.
+#' If also `lodcolumn` is NULL, you get a vector with the maximum LOD for each column.
 #'
 #' If `map` is provided, the return value is a data.frame with three columns: chr, pos, and lod score.
+#' But if `lodcolumn` is NULL, you get the maximum for each lod score column, in the format provided by
+#' [find_peaks()], so a data.frame with five columns: lodindex, lodcolumn, chr, pos, and lod.
 #'
 #' @examples
 #' # read data
@@ -53,11 +57,14 @@
 #' # maximum of first column on chr 2
 #' max(out, map, chr="2")
 max_scan1 <-
-    function(scan1_output, map, lodcolumn=1, chr=NULL, na.rm=TRUE, ...)
+    function(scan1_output, map=NULL, lodcolumn=1, chr=NULL, na.rm=TRUE, ...)
 {
     if(is.null(scan1_output)) stop("scan1_output is NULL")
 
-    if(length(lodcolumn) == 0) stop("lodcolumn has length 0")
+    if(is.null(lodcolumn)) {
+        return(maxall_scan1(scan1_output, map=map, chr=chr, na.rm=na.rm, ...))
+    }
+
     if(length(lodcolumn) > 1) {
         lodcolumn <- lodcolumn[1]
         warning("lodcolumn should have length 1; using the first value")
@@ -140,7 +147,7 @@ max_scan1 <-
 #' @export
 #' @rdname max_scan1
 max.scan1 <-
-    function(scan1_output, map, lodcolumn=1, chr=NULL, na.rm=TRUE, ...)
+    function(scan1_output, map=NULL, lodcolumn=1, chr=NULL, na.rm=TRUE, ...)
     max_scan1(scan1_output, map, lodcolumn, chr, na.rm, ...)
 
 #' Overall maximum LOD score
@@ -217,4 +224,26 @@ maxlod <-
         lod <- unclass(scan1_output)
         return(max(lod))
     }
+}
+
+# return maximum for all lod score columns
+maxall_scan1 <-
+    function(scan1_output, map=NULL, chr=NULL, na.rm=TRUE, ...)
+{
+    if(is.null(map)) {
+        if(!is.null(chr)) warning("chr ignored if map is not provided.")
+
+        return(apply(scan1_output, 2, max, na.rm=na.rm))
+    }
+
+    res <- lapply(1:ncol(scan1_output), function(lodcol) max_scan1(scan1_output, map=map, lodcolumn=lodcol,
+                                                                   chr=chr, na.rm=na.rm, ...))
+
+    data.frame(lodindex=1:ncol(scan1_output),
+               lodcolumn=colnames(scan1_output),
+               chr=sapply(res, function(a) a[[1]][1]),
+               pos=sapply(res, function(a) a[[2]][1]),
+               lod=sapply(res, function(a) a[[3]][1]),
+               stringsAsFactors=FALSE)
+
 }

--- a/R/max_scan1.R
+++ b/R/max_scan1.R
@@ -78,8 +78,9 @@ max_scan1 <-
         stop("column [", lodcolumn, "] out of range (should be in 1, ..., ", ncol(lod), ")")
     }
 
-    if(missing(map) || is.null(map)) {
-        warning("map not provided; returning the genome-wide maximum LOD but not its position")
+    if(is.null(map)) {
+        if(!is.null(chr)) warning("chr ignored if map is not provided")
+
         return( setNames( max(scan1_output[,lodcolumn], na.rm=TRUE), colnames(scan1_output)[lodcolumn]) )
     }
 
@@ -231,7 +232,6 @@ maxall_scan1 <-
     function(scan1_output, map=NULL, chr=NULL, na.rm=TRUE, ...)
 {
     if(is.null(map)) {
-        warning("map not provided; returning the genome-wide maximum LODs but not their positions")
         if(!is.null(chr)) warning("chr ignored if map is not provided.")
 
         return(apply(scan1_output, 2, max, na.rm=na.rm))

--- a/man/max_scan1.Rd
+++ b/man/max_scan1.Rd
@@ -5,9 +5,10 @@
 \alias{max.scan1}
 \title{Find position with maximum LOD score}
 \usage{
-max_scan1(scan1_output, map, lodcolumn = 1, chr = NULL, na.rm = TRUE, ...)
+max_scan1(scan1_output, map = NULL, lodcolumn = 1, chr = NULL,
+  na.rm = TRUE, ...)
 
-\method{max}{scan1}(scan1_output, map, lodcolumn = 1, chr = NULL,
+\method{max}{scan1}(scan1_output, map = NULL, lodcolumn = 1, chr = NULL,
   na.rm = TRUE, ...)
 }
 \arguments{
@@ -19,7 +20,8 @@ max_scan1(scan1_output, map, lodcolumn = 1, chr = NULL, na.rm = TRUE, ...)
 as from \code{\link[=index_snps]{index_snps()}} or \code{\link[=scan1snps]{scan1snps()}}.}
 
 \item{lodcolumn}{An integer or character string indicating the LOD
-score column, either as a numeric index or column name.}
+score column, either as a numeric index or column name.
+If \code{NULL}, return maximum for all columns.}
 
 \item{chr}{Option vector of chromosomes to consider.}
 
@@ -29,8 +31,11 @@ score column, either as a numeric index or column name.}
 }
 \value{
 If \code{map} is NULL, the genome-wide maximum LOD score for the selected column is returned.
+If also \code{lodcolumn} is NULL, you get a vector with the maximum LOD for each column.
 
 If \code{map} is provided, the return value is a data.frame with three columns: chr, pos, and lod score.
+But if \code{lodcolumn} is NULL, you get the maximum for each lod score column, in the format provided by
+\code{\link[=find_peaks]{find_peaks()}}, so a data.frame with five columns: lodindex, lodcolumn, chr, pos, and lod.
 }
 \description{
 Return data frame with the positions having maximum LOD score for a

--- a/tests/testthat/test-max_scan1.R
+++ b/tests/testthat/test-max_scan1.R
@@ -55,6 +55,48 @@ test_that("max_scan1 works for intercross with two phenotypes", {
     expect_warning( expect_equal(max_scan1(out, lodcolumn=2), c(spleen=12.5986057120873)) )
     expect_warning( expect_equal(max_scan1(out, lodcolumn="spleen"), c(spleen=12.5986057120873)) )
 
+    # warning if you give lodcolumn as a vector
+    expect_warning( expect_equal(max(out, lodcolumn=1:2), c(liver= 6.35264382891418)) )
+    expected <- data.frame(chr="16",
+                           pos=28.6,
+                           liver=max(out[,1]),
+                           stringsAsFactors=FALSE)
+    rownames(expected) <- "c16.loc29"
+    expect_warning( expect_equal( max(out, map, lodcolumn=1:2), expected) )
+
+    # results for all LOD score columns if lodcolumn=NULL
+    expect_warning( expect_equal( max(out, lodcolumn=NULL),
+                                  c(liver= 6.35264382891418, spleen=12.5986057120873) ))
+
+
+    expected <- data.frame(lodindex=1:ncol(out),
+                           lodcolumn=colnames(out),
+                           chr=c("16","9"),
+                           pos=c(28.6, 56.6),
+                           lod=apply(out, 2, max),
+                           stringsAsFactors=FALSE)
+    rownames(expected) <- NULL
+    expect_equal( max(out, map, lodcolumn=NULL), expected )
+
+    expected <- data.frame(lodindex=1:ncol(out),
+                           lodcolumn=colnames(out),
+                           chr=c("16","16"),
+                           pos=c(28.6, 30.6),
+                           lod=apply(subset(out, map, chr=16), 2, max),
+                           stringsAsFactors=FALSE)
+    rownames(expected) <- NULL
+    expect_equal( max(out, map, lodcolumn=NULL, chr=16), expected )
+
+    expected <- data.frame(lodindex=1:ncol(out),
+                           lodcolumn=colnames(out),
+                           chr=c("3","9"),
+                           pos=c(25.1, 56.6),
+                           lod=apply(subset(out, map, chr=c(3,9)), 2, max),
+                           stringsAsFactors=FALSE)
+    rownames(expected) <- NULL
+    expect_equal( max(out, map, lodcolumn=NULL, chr=c(3,9)), expected )
+    expect_equal( max(out, map, lodcolumn=NULL, chr=c(9,3)), expected )
+
 })
 
 test_that("maxlod works for intercross with two phenotypes", {

--- a/tests/testthat/test-max_scan1.R
+++ b/tests/testthat/test-max_scan1.R
@@ -51,9 +51,9 @@ test_that("max_scan1 works for intercross with two phenotypes", {
     class(out_shuffled) <- c("scan1", "matrix")
     expect_equal( max(out_shuffled, map), max(out, map))
 
-    expect_warning( expect_equal(max_scan1(out), c(liver= 6.35264382891418)) )
-    expect_warning( expect_equal(max_scan1(out, lodcolumn=2), c(spleen=12.5986057120873)) )
-    expect_warning( expect_equal(max_scan1(out, lodcolumn="spleen"), c(spleen=12.5986057120873)) )
+    expect_equal(max_scan1(out), c(liver= 6.35264382891418))
+    expect_equal(max_scan1(out, lodcolumn=2), c(spleen=12.5986057120873))
+    expect_equal(max_scan1(out, lodcolumn="spleen"), c(spleen=12.5986057120873))
 
     # warning if you give lodcolumn as a vector
     expect_warning( expect_equal(max(out, lodcolumn=1:2), c(liver= 6.35264382891418)) )
@@ -64,9 +64,12 @@ test_that("max_scan1 works for intercross with two phenotypes", {
     rownames(expected) <- "c16.loc29"
     expect_warning( expect_equal( max(out, map, lodcolumn=1:2), expected) )
 
+    # warning if you give chr but not map
+    expect_warning( expect_equal( max(out, lodcolumn=2, chr=16), c(spleen=12.5986057120873)) )
+
     # results for all LOD score columns if lodcolumn=NULL
-    expect_warning( expect_equal( max(out, lodcolumn=NULL),
-                                  c(liver= 6.35264382891418, spleen=12.5986057120873) ))
+    expect_equal( max(out, lodcolumn=NULL),
+                 c(liver= 6.35264382891418, spleen=12.5986057120873) )
 
 
     expected <- data.frame(lodindex=1:ncol(out),


### PR DESCRIPTION
In `max_scan1()`, now allow `lodcolumn=NULL` which results in maximum for all possible LOD score columns. We still don't allow `lodcolumn` to be a vector.

Also, got rid of the warning when `map` is NULL. (Unless `map` is NULL and `chr` is provided; that'll give a warning.)

It's not ideal that the output can be a number of different formats: a single LOD score, a vector of LOD scores, a data frame with 3 columns, or a data frame with 5 columns.