### PR TITLE
Implement chr argument in plot_snpasso()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.15-20
-Date: 2018-07-16
+Version: 0.15-21
+Date: 2018-07-17
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2 0.15-20 (2018-07-16)
+## qtl2 0.15-21 (2018-07-17)
 
 ### New features
 
@@ -58,6 +58,8 @@
 
 - Add `overwrite` argument (default `FALSE`) to `zip_datafiles()`,
   similar to that for `write_control_file()`.
+
+- `plot_snpasso()` now takes an argument `chr`.
 
 - `max_scan1()` no longer gives a warning if `map` is not provided.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,10 @@
 - Fix a bug in `index_snps()`; messed up results when `start` and
   `end` outside the range of the map.
 
+- Fix a bug in `scan1snps()` regarding use of `chr` argument: need to
+  force to be unique character strings, and avoid unnecessary warning
+  about `start` and `end`.
+
 
 ## qtl2 0.14 (2018-03-09)
 

--- a/R/plot_scan1.R
+++ b/R/plot_scan1.R
@@ -238,7 +238,7 @@ plot.scan1 <-
 
     # if map looks like snpinfo, assume this is a snp asso result and use plot_snpasso()
     if(is.data.frame(map) && "index" %in% names(map)) {
-        plot_snpasso(x, snpinfo=map, lodcolumn=lodcolumn, add=add, gap=gap, ...)
+        plot_snpasso(x, snpinfo=map, lodcolumn=lodcolumn, add=add, gap=gap, chr=chr, ...)
     }
     else { # mostly, use plot_scan1()
         plot_scan1(x, map=map, lodcolumn=lodcolumn, chr=chr, add=add, gap=gap, ...)

--- a/R/plot_snpasso.R
+++ b/R/plot_snpasso.R
@@ -37,6 +37,8 @@
 #'
 #' @param show_all_snps If TRUE, expand to show all SNPs.
 #'
+#' @param chr Vector of character strings with chromosome IDs to plot.
+#'
 #' @param add If TRUE, add to current plot (must have same map and
 #' chromosomes).
 #'
@@ -111,8 +113,8 @@
 #' @export
 #'
 plot_snpasso <-
-    function(scan1output, snpinfo, genes=NULL, lodcolumn=1, show_all_snps=TRUE, add=FALSE,
-             drop_hilit=NA, col_hilit="violetred", col="darkslateblue",
+    function(scan1output, snpinfo, genes=NULL, lodcolumn=1, show_all_snps=TRUE, chr=NULL,
+             add=FALSE, drop_hilit=NA, col_hilit="violetred", col="darkslateblue",
              gap=25, minlod=0, ...)
 {
     if(is.null(scan1output)) stop("scan1output is NULL")
@@ -135,6 +137,15 @@ plot_snpasso <-
     if(lodcolumn < 1 || lodcolumn > ncol(scan1output))
         stop("lodcolumn [", lodcolumn, "] out of range (should be in 1, ..., ", ncol(scan1output), ")")
     scan1output <- scan1output[,lodcolumn,drop=FALSE]
+
+    if(!is.null(chr)) { # subset by chr
+        if(!any(chr %in% snpinfo$chr)) stop("None of the chr found in snpinfo")
+        if(!all(chr %in% snpinfo$chr)) {
+            warning("Some chr not found: ", paste(chr[!(chr %in% snpinfo$chr)], collapse=", "))
+        }
+        snpinfo <- snpinfo[snpinfo$chr %in% chr,,drop=FALSE]
+        scan1output <- scan1output[rownames(scan1output) %in% snpinfo$snp,,drop=FALSE]
+    }
 
     if(!is.null(genes)) {
         if(length(unique(snpinfo$chr)) > 1) {

--- a/R/scan1snps.R
+++ b/R/scan1snps.R
@@ -120,14 +120,17 @@ scan1snps <-
         warning("If snpinfo is provided, chr, start, end, and query_func are all ignored")
     }
 
+    if(!is.null(chr)) chr <- unique(as.character(chr)) # make sure chr is character strings
+
     if(!is.null(chr) || !is.null(start) || !is.null(end)) { # defined region
         if(!is.null(snpinfo)) warning("If snpinfo provided, chr, start, end, and query_func are all ignored")
         if(is.null(chr)) stop("If start and/or end provided, need to give chr as well")
         if(is.null(query_func)) stop("If chr, start, and/or end provided, need to give query_func too")
-        if(is.null(start)) start <- -1e15
-        if(is.null(end)) end <- 1e15
 
         if(length(chr) == 1) {
+            if(is.null(start)) start <- -1e15
+            if(is.null(end)) end <- 1e15
+
             if(length(start) > 1 || length(end) > 1) {
                 warning("start and end should have length 1; using the first values")
                 start <- start[1]
@@ -143,6 +146,7 @@ scan1snps <-
         if(!is.null(start) || !is.null(end)) {
             warning("If length(chr) > 1, start end end are ignored.")
         }
+
         if(!all(chr %in% names(map))) {
             stop("Not all chromosomes found: ", paste(chr[!(chr %in% names(map))], collapse=", "))
         }

--- a/man/plot_snpasso.Rd
+++ b/man/plot_snpasso.Rd
@@ -5,7 +5,7 @@
 \title{Plot SNP associations}
 \usage{
 plot_snpasso(scan1output, snpinfo, genes = NULL, lodcolumn = 1,
-  show_all_snps = TRUE, add = FALSE, drop_hilit = NA,
+  show_all_snps = TRUE, chr = NULL, add = FALSE, drop_hilit = NA,
   col_hilit = "violetred", col = "darkslateblue", gap = 25, minlod = 0,
   ...)
 }
@@ -44,6 +44,8 @@ gene locations below.}
 character string for a column name). Only one value allowed.}
 
 \item{show_all_snps}{If TRUE, expand to show all SNPs.}
+
+\item{chr}{Vector of character strings with chromosome IDs to plot.}
 
 \item{add}{If TRUE, add to current plot (must have same map and
 chromosomes).}


### PR DESCRIPTION
- Fixes Issue #57, implementing `chr` argument to `plot_snpasso()`. Also need to pass `chr` from `plot_scan1()`.

- Also fixed bug in `scan1snps()`, ensuring `chr` argument is a set of distinct character strings, and avoiding unnecessary warning about `start` and `end` when `chr` has length > 1.