### PR TITLE
Added more control over binary trait regression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,9 @@
 - `insert_pseudomarkers()` will now accept `pseudomarker_map` that
    includes only a portion of the chromosomes.
 
+- In `fit1()`, replaced `tol` and `maxit` and added `...` which takes
+  these plus a few additional hidden control parameters.
+
 ### Bug fixes
 
 - Fix a bug in `index_snps()`; messed up results when `start` and

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,76 +9,76 @@ arrange_genes <- function(start, end) {
     .Call(`_qtl2_R_bayes_int_plain`, lod, pos, prob)
 }
 
-calc_ll_binreg_eigenchol <- function(X, y, maxit = 100L, tol = 1e-6) {
-    .Call(`_qtl2_calc_ll_binreg_eigenchol`, X, y, maxit, tol)
+calc_ll_binreg_eigenchol <- function(X, y, maxit = 100L, tol = 1e-6, nu_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_eigenchol`, X, y, maxit, tol, nu_max)
 }
 
-calc_ll_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_ll_binreg_eigenqr`, X, y, maxit, tol, qr_tol)
+calc_ll_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_eigenqr`, X, y, maxit, tol, qr_tol, nu_max)
 }
 
-calc_coef_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_coef_binreg_eigenqr`, X, y, maxit, tol, qr_tol)
+calc_coef_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_coef_binreg_eigenqr`, X, y, maxit, tol, qr_tol, nu_max)
 }
 
-calc_coefSE_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_coefSE_binreg_eigenqr`, X, y, maxit, tol, qr_tol)
+calc_coefSE_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_coefSE_binreg_eigenqr`, X, y, maxit, tol, qr_tol, nu_max)
 }
 
-fit_binreg_eigenqr <- function(X, y, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_fit_binreg_eigenqr`, X, y, se, maxit, tol, qr_tol)
+fit_binreg_eigenqr <- function(X, y, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_fit_binreg_eigenqr`, X, y, se, maxit, tol, qr_tol, nu_max)
 }
 
-calc_ll_binreg_weighted_eigenchol <- function(X, y, weights, maxit = 100L, tol = 1e-6) {
-    .Call(`_qtl2_calc_ll_binreg_weighted_eigenchol`, X, y, weights, maxit, tol)
+calc_ll_binreg_weighted_eigenchol <- function(X, y, weights, maxit = 100L, tol = 1e-6, nu_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_weighted_eigenchol`, X, y, weights, maxit, tol, nu_max)
 }
 
-calc_ll_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_ll_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol)
+calc_ll_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, nu_max)
 }
 
-calc_coef_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_coef_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol)
+calc_coef_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_coef_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, nu_max)
 }
 
-calc_coefSE_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_coefSE_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol)
+calc_coefSE_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_coefSE_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, nu_max)
 }
 
-fit_binreg_weighted_eigenqr <- function(X, y, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_fit_binreg_weighted_eigenqr`, X, y, weights, se, maxit, tol, qr_tol)
+fit_binreg_weighted_eigenqr <- function(X, y, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_fit_binreg_weighted_eigenqr`, X, y, weights, se, maxit, tol, qr_tol, nu_max)
 }
 
-calc_ll_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_ll_binreg_weighted`, X, y, weights, maxit, tol, qr_tol)
+calc_ll_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, nu_max)
 }
 
-calc_coef_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_coef_binreg_weighted`, X, y, weights, maxit, tol, qr_tol)
+calc_coef_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_coef_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, nu_max)
 }
 
-calc_coefSE_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_coefSE_binreg_weighted`, X, y, weights, maxit, tol, qr_tol)
+calc_coefSE_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_coefSE_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, nu_max)
 }
 
-fit_binreg_weighted <- function(X, y, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_fit_binreg_weighted`, X, y, weights, se, maxit, tol, qr_tol)
+fit_binreg_weighted <- function(X, y, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_fit_binreg_weighted`, X, y, weights, se, maxit, tol, qr_tol, nu_max)
 }
 
-calc_ll_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_ll_binreg`, X, y, maxit, tol, qr_tol)
+calc_ll_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg`, X, y, maxit, tol, qr_tol, nu_max)
 }
 
-calc_coef_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_coef_binreg`, X, y, maxit, tol, qr_tol)
+calc_coef_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_coef_binreg`, X, y, maxit, tol, qr_tol, nu_max)
 }
 
-calc_coefSE_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_calc_coefSE_binreg`, X, y, maxit, tol, qr_tol)
+calc_coefSE_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_calc_coefSE_binreg`, X, y, maxit, tol, qr_tol, nu_max)
 }
 
-fit_binreg <- function(X, y, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_fit_binreg`, X, y, se, maxit, tol, qr_tol)
+fit_binreg <- function(X, y, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_fit_binreg`, X, y, se, maxit, tol, qr_tol, nu_max)
 }
 
 .calc_kinship <- function(prob_array) {
@@ -165,12 +165,12 @@ invert_founder_index <- function(cross_info) {
     .Call(`_qtl2_R_find_peaks_and_bayesint`, lod, pos, threshold, peakdrop, prob)
 }
 
-fit1_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, se = FALSE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_fit1_binary_addcovar`, genoprobs, pheno, addcovar, weights, se, maxit, tol, qr_tol)
+fit1_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, se = FALSE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_fit1_binary_addcovar`, genoprobs, pheno, addcovar, weights, se, maxit, tol, qr_tol, nu_max)
 }
 
-fit1_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_fit1_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, se, maxit, tol, qr_tol)
+fit1_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_fit1_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, se, maxit, tol, qr_tol, nu_max)
 }
 
 fit1_hk_addcovar <- function(genoprobs, pheno, addcovar, weights, se = FALSE, tol = 1e-12) {
@@ -461,12 +461,12 @@ permute_ivector_stratified <- function(n_perm, x, strata, n_strata = -1L) {
     .Call(`_qtl2_reduce_markers`, pos, min_dist, weights)
 }
 
-scan_binary_onechr <- function(genoprobs, pheno, addcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_scan_binary_onechr`, genoprobs, pheno, addcovar, maxit, tol, qr_tol)
+scan_binary_onechr <- function(genoprobs, pheno, addcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_scan_binary_onechr`, genoprobs, pheno, addcovar, maxit, tol, qr_tol, nu_max)
 }
 
-scan_binary_onechr_weighted <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_scan_binary_onechr_weighted`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol)
+scan_binary_onechr_weighted <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_scan_binary_onechr_weighted`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max)
 }
 
 scan_binary_onechr_intcovar_highmem <- function(genoprobs, pheno, addcovar, intcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
@@ -477,12 +477,12 @@ scan_binary_onechr_intcovar_weighted_highmem <- function(genoprobs, pheno, addco
     .Call(`_qtl2_scan_binary_onechr_intcovar_weighted_highmem`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol)
 }
 
-scan_binary_onechr_intcovar_lowmem <- function(genoprobs, pheno, addcovar, intcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_scan_binary_onechr_intcovar_lowmem`, genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol)
+scan_binary_onechr_intcovar_lowmem <- function(genoprobs, pheno, addcovar, intcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_scan_binary_onechr_intcovar_lowmem`, genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, nu_max)
 }
 
-scan_binary_onechr_intcovar_weighted_lowmem <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_scan_binary_onechr_intcovar_weighted_lowmem`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol)
+scan_binary_onechr_intcovar_weighted_lowmem <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_scan_binary_onechr_intcovar_weighted_lowmem`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max)
 }
 
 scan_hk_onechr_nocovar <- function(genoprobs, pheno, tol = 1e-12) {
@@ -529,20 +529,20 @@ scanblup <- function(genoprobs, pheno, addcovar, se, reml, tol = 1e-12) {
     .Call(`_qtl2_scanblup`, genoprobs, pheno, addcovar, se, reml, tol)
 }
 
-scancoef_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_scancoef_binary_addcovar`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol)
+scancoef_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_scancoef_binary_addcovar`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max)
 }
 
-scancoef_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_scancoef_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol)
+scancoef_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_scancoef_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max)
 }
 
-scancoefSE_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_scancoefSE_binary_addcovar`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol)
+scancoefSE_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_scancoefSE_binary_addcovar`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max)
 }
 
-scancoefSE_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
-    .Call(`_qtl2_scancoefSE_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol)
+scancoefSE_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
+    .Call(`_qtl2_scancoefSE_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max)
 }
 
 scancoef_hk_addcovar <- function(genoprobs, pheno, addcovar, weights, tol = 1e-12) {

--- a/R/fit1_pg.R
+++ b/R/fit1_pg.R
@@ -4,9 +4,13 @@ fit1_pg <-
     function(genoprobs, pheno, kinship,
              addcovar=NULL, nullcovar=NULL, intcovar=NULL,
              weights=NULL, contrasts=NULL, se=FALSE,
-             hsq=NULL, reml=TRUE, tol=1e-12)
+             hsq=NULL, reml=TRUE, ...)
 {
-    stopifnot(tol > 0)
+    # deal with the dot args
+    dotargs <- list("...")
+    tol <- grab_dots(dotargs, "tol", 1e-12)
+    if(!is_pos_number(tol)) stop("tol should be a single positive number")
+    check_extra_dots(dotargs, "tol")
 
     # check that the objects have rownames
     check4names(pheno, addcovar, NULL, intcovar, nullcovar)

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -62,17 +62,22 @@
 #' object should have a component `"is_x_chr"` that indicates
 #' which of the chromosomes is the X chromosome, if any.
 #'
-#' The `...` argument can contain three additional control
+#' The `...` argument can contain several additional control
 #' parameters; suspended for simplicity (or confusion, depending on
-#' your point of view). `tol` is used as a tolerance value for
-#' linear regression by QR decomposition (in determining whether
-#' columns are linearly dependent on others and should be omitted);
-#' default `1e-12`. `intcovar_method` indicates whether to
-#' use a high-memory (but potentially faster) method or a low-memory
-#' (and possibly slower) method, with values `"highmem"` or
-#' `"lowmem"`; default `"lowmem"`. Finally, `max_batch`
-#' indicates the maximum number of phenotypes to run together; default
-#' is unlimited.
+#' your point of view). `tol` is used as a tolerance value for linear
+#' regression by QR decomposition (in determining whether columns are
+#' linearly dependent on others and should be omitted); default
+#' `1e-12`. `intcovar_method` indicates whether to use a high-memory
+#' (but potentially faster) method or a low-memory (and possibly
+#' slower) method, with values `"highmem"` or `"lowmem"`; default
+#' `"lowmem"`. `max_batch` indicates the maximum number of phenotypes
+#' to run together; default is unlimited. `maxit` is the maximum
+#' number of iteractions for converence of the iterative algorithm
+#' used when `model=binary`. `bintol` is used as a tolerance for
+#' converence for the iterative algorithm used when `model=binary`.
+#' `nu_max` is the maximum value for the "linear predictor" in the
+#' case `model="binary"` (a bit of a technicality to avoid fitted
+#' values exactly at 0 or 1).
 #'
 #' If `kinship` is absent, Haley-Knott regression is performed.
 #' If `kinship` is provided, a linear mixed model is used, with a
@@ -145,16 +150,23 @@ scan1 <-
     # deal with the dot args
     tol <- grab_dots(dotargs, "tol", 1e-12)
     if(!is_pos_number(tol)) stop("tol should be a single positive number")
-    bintol <- grab_dots(dotargs, "bintol", sqrt(tol)) # for model="binary"
-    stopifnot(bintol > 0)
     intcovar_method <- grab_dots(dotargs, "intcovar_method", "lowmem",
                                  c("highmem", "lowmem"))
     quiet <- grab_dots(dotargs, "quiet", TRUE)
     max_batch <- grab_dots(dotargs, "max_batch", NULL)
     if(!is.null(max_batch) && !is_pos_number(max_batch)) stop("max_batch should be a single positive integer")
-    maxit <- grab_dots(dotargs, "maxit", 100) # for model="binary"
-    if(!is_nonneg_number(maxit)) stop("maxit should be a single non-negative integer")
-    check_extra_dots(dotargs, c("tol", "intcovar_method", "quiet", "max_batch", "maxit"))
+    if(model=="binary") {
+        bintol <- grab_dots(dotargs, "bintol", sqrt(tol)) # for model="binary"
+        if(!is_pos_number(bintol)) stop("bintol should be a single positive number")
+        nu_max <- grab_dots(dotargs, "nu_max", 30) # for model="binary"
+        if(!is_pos_number(nu_max)) stop("nu_max should be a single positive number")
+        maxit <- grab_dots(dotargs, "maxit", 100) # for model="binary"
+        if(!is_nonneg_number(maxit)) stop("maxit should be a single non-negative integer")
+        check_extra_dots(dotargs, c("tol", "intcovar_method", "quiet", "max_batch", "maxit", "bintol", "nu_max"))
+    }
+    else {
+        check_extra_dots(dotargs, c("tol", "intcovar_method", "quiet", "max_batch"))
+    }
 
     # check that the objects have rownames
     check4names(pheno, addcovar, Xcovar, intcovar)
@@ -277,11 +289,11 @@ scan1 <-
         }
         else { # binary traits
             # FIX_ME: calculating null LOD multiple times :(
-            nulllod <- null_binary_clean(ph, ac0, wts, add_intercept=TRUE, maxit, bintol, tol)
+            nulllod <- null_binary_clean(ph, ac0, wts, add_intercept=TRUE, maxit, bintol, tol, nu_max)
 
             # scan1 function taking clean data (with no missing values)
             lod <- scan1_binary_clean(pr, ph, ac, ic, wts, add_intercept=TRUE,
-                                      maxit, bintol, tol, intcovar_method)
+                                      maxit, bintol, tol, intcovar_method, nu_max)
 
             # calculate LOD score
             lod <- lod - nulllod

--- a/R/scan1_binary.R
+++ b/R/scan1_binary.R
@@ -6,7 +6,7 @@
 scan1_binary_clean <-
     function(genoprobs, pheno, addcovar, intcovar,
              weights, add_intercept=TRUE, maxit, tol, qr_tol,
-             intcovar_method)
+             intcovar_method, nu_max=30)
 {
     n <- nrow(pheno)
     if(add_intercept)
@@ -15,9 +15,9 @@ scan1_binary_clean <-
     if(is.null(intcovar)) { # no interactive covariates
 
         if(is.null(weights)) { # no weights
-            return( scan_binary_onechr(genoprobs, pheno, addcovar, maxit, tol, qr_tol) )
+            return( scan_binary_onechr(genoprobs, pheno, addcovar, maxit, tol, qr_tol, nu_max) )
         } else { # weights included
-            return( scan_binary_onechr_weighted(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol) )
+            return( scan_binary_onechr_weighted(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max) )
         }
 
     } else { # interactive covariates
@@ -30,9 +30,9 @@ scan1_binary_clean <-
                        scan_binary_onechr_intcovar_weighted_lowmem)
 
         if(is.null(weights)) { # no weights
-            return( scanf[[1]](genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol) )
+            return( scanf[[1]](genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, nu_max) )
         } else { # weights included
-            return( scanf[[2]](genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol) )
+            return( scanf[[2]](genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max) )
         }
 
     }
@@ -40,16 +40,17 @@ scan1_binary_clean <-
 
 # calculate null log likelihood, with nicely aligned data with no missing values
 null_binary_clean <-
-    function(pheno, addcovar, weights, add_intercept=TRUE, maxit, tol, qr_tol)
+    function(pheno, addcovar, weights, add_intercept=TRUE, maxit, tol, qr_tol, nu_max=30)
 {
     n <- nrow(pheno)
     if(add_intercept)
         addcovar <- cbind(rep(1,n), addcovar) # add intercept
 
     if(is.null(weights) || length(weights)==0) { # no weights
-        result <- apply(pheno, 2, function(phe) calc_ll_binreg(addcovar, phe, maxit, tol, qr_tol))
+        result <- apply(pheno, 2, function(phe) calc_ll_binreg(addcovar, phe, maxit, tol, qr_tol, nu_max))
     } else { # weights included
-        result <- apply(pheno, 2, function(phe) calc_ll_binreg_weighted(addcovar, phe, weights, maxit, tol, qr_tol))
+        result <- apply(pheno, 2, function(phe) calc_ll_binreg_weighted(addcovar, phe, weights, maxit, tol,
+                                                                        qr_tol, nu_max))
     }
 
     as.numeric(result)

--- a/R/scan1_pg.R
+++ b/R/scan1_pg.R
@@ -9,8 +9,6 @@ scan1_pg <-
     dotargs <- list(...)
     tol <- grab_dots(dotargs, "tol", 1e-12)
     if(!is_pos_number(tol)) stop("tol should be a single positive number")
-    bintol <- grab_dots(dotargs, "bintol", sqrt(tol)) # for model="binary"
-    stopifnot(bintol > 0)
     intcovar_method <- grab_dots(dotargs, "intcovar_method", "lowmem",
                                  c("highmem", "lowmem"))
     quiet <- grab_dots(dotargs, "quiet", TRUE)

--- a/R/scan1coef.R
+++ b/R/scan1coef.R
@@ -122,6 +122,7 @@ scan1coef <-
 
     if(!is_pos_number(tol)) stop("tol should be a single positive number")
     bintol <- sqrt(tol)
+    nu_max <- 30
 
     # check that the objects have rownames
     check4names(pheno, addcovar, NULL, intcovar, nullcovar)
@@ -222,7 +223,7 @@ scan1coef <-
             if(model=="normal")
                 result <- scancoefSE_hk_addcovar(genoprobs, pheno, addcovar, weights, tol)
             else # binary trait
-                result <- scancoefSE_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, bintol, tol)
+                result <- scancoefSE_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, bintol, tol, nu_max)
         }
         else {                  # intcovar
             if(model=="normal")
@@ -230,7 +231,7 @@ scan1coef <-
                                                  weights, tol)
             else
                 result <- scancoefSE_binary_intcovar(genoprobs, pheno, addcovar, intcovar,
-                                                 weights, maxit, bintol, tol)
+                                                 weights, maxit, bintol, tol, nu_max)
         }
 
         SE <- t(result$SE) # transpose to positions x coefficients
@@ -242,7 +243,7 @@ scan1coef <-
             if(model=="normal")
                 result <- scancoef_hk_addcovar(genoprobs, pheno, addcovar, weights, tol)
             else
-                result <- scancoef_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, bintol, tol)
+                result <- scancoef_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, bintol, tol, nu_max)
         }
         else {                  # intcovar
             if(model=="normal")
@@ -250,7 +251,7 @@ scan1coef <-
                                                weights, tol)
             else
                 result <- scancoef_binary_intcovar(genoprobs, pheno, addcovar, intcovar,
-                                                   weights, maxit, bintol, tol)
+                                                   weights, maxit, bintol, tol, nu_max)
         }
         SE <- NULL
     }

--- a/man/fit1.Rd
+++ b/man/fit1.Rd
@@ -6,8 +6,7 @@
 \usage{
 fit1(genoprobs, pheno, kinship = NULL, addcovar = NULL, nullcovar = NULL,
   intcovar = NULL, weights = NULL, contrasts = NULL, model = c("normal",
-  "binary"), se = TRUE, hsq = NULL, reml = TRUE, tol = 0.000000000001,
-  maxit = 100)
+  "binary"), se = TRUE, hsq = NULL, reml = TRUE, ...)
 }
 \arguments{
 \item{genoprobs}{A matrix of genotype probabilities, individuals x genotypes}
@@ -51,12 +50,7 @@ If \code{model="binary"}, the phenotypes must have values in
 \item{reml}{If \code{kinship} provided: if \code{reml=TRUE}, use
 REML; otherwise maximum likelihood.}
 
-\item{tol}{Tolerance value for
-linear regression by QR decomposition (in determining whether
-columns are linearly dependent on others and should be omitted)}
-
-\item{maxit}{Maximum number of iterations in logistic regression
-fit (when \code{model="binary"}).}
+\item{...}{Additional control parameters; see Details;}
 }
 \value{
 A list containing
@@ -89,6 +83,18 @@ matrix in the model. One might view the rows of
 as the set of contrasts, as the estimated effects are the estimated
 genotype effects pre-multiplied by
 \ifelse{html}{\out{<em>A</em><sup>-1</sup>}}{\eqn{A^{-1}}}.
+
+The \code{...} argument can contain several additional control
+parameters; suspended for simplicity (or confusion, depending on
+your point of view). \code{tol} is used as a tolerance value for linear
+regression by QR decomposition (in determining whether columns are
+linearly dependent on others and should be omitted); default
+\code{1e-12}. \code{maxit} is the maximum number of iteractions for
+converence of the iterative algorithm used when \code{model=binary}.
+\code{bintol} is used as a tolerance for converence for the iterative
+algorithm used when \code{model=binary}. \code{nu_max} is the maximum value
+for the "linear predictor" in the case \code{model="binary"} (a bit of a
+technicality to avoid fitted values exactly at 0 or 1).
 }
 \examples{
 # read data

--- a/man/scan1.Rd
+++ b/man/scan1.Rd
@@ -83,17 +83,22 @@ individual identifiers, to align individuals. The \code{genoprobs}
 object should have a component \code{"is_x_chr"} that indicates
 which of the chromosomes is the X chromosome, if any.
 
-The \code{...} argument can contain three additional control
+The \code{...} argument can contain several additional control
 parameters; suspended for simplicity (or confusion, depending on
-your point of view). \code{tol} is used as a tolerance value for
-linear regression by QR decomposition (in determining whether
-columns are linearly dependent on others and should be omitted);
-default \code{1e-12}. \code{intcovar_method} indicates whether to
-use a high-memory (but potentially faster) method or a low-memory
-(and possibly slower) method, with values \code{"highmem"} or
-\code{"lowmem"}; default \code{"lowmem"}. Finally, \code{max_batch}
-indicates the maximum number of phenotypes to run together; default
-is unlimited.
+your point of view). \code{tol} is used as a tolerance value for linear
+regression by QR decomposition (in determining whether columns are
+linearly dependent on others and should be omitted); default
+\code{1e-12}. \code{intcovar_method} indicates whether to use a high-memory
+(but potentially faster) method or a low-memory (and possibly
+slower) method, with values \code{"highmem"} or \code{"lowmem"}; default
+\code{"lowmem"}. \code{max_batch} indicates the maximum number of phenotypes
+to run together; default is unlimited. \code{maxit} is the maximum
+number of iteractions for converence of the iterative algorithm
+used when \code{model=binary}. \code{bintol} is used as a tolerance for
+converence for the iterative algorithm used when \code{model=binary}.
+\code{nu_max} is the maximum value for the "linear predictor" in the
+case \code{model="binary"} (a bit of a technicality to avoid fitted
+values exactly at 0 or 1).
 
 If \code{kinship} is absent, Haley-Knott regression is performed.
 If \code{kinship} is provided, a linear mixed model is used, with a

--- a/man/scan1coef.Rd
+++ b/man/scan1coef.Rd
@@ -7,7 +7,7 @@
 scan1coef(genoprobs, pheno, kinship = NULL, addcovar = NULL,
   nullcovar = NULL, intcovar = NULL, weights = NULL, contrasts = NULL,
   model = c("normal", "binary"), se = FALSE, hsq = NULL, reml = TRUE,
-  tol = 0.000000000001, maxit = 100)
+  tol = 1e-12, maxit = 100)
 }
 \arguments{
 \item{genoprobs}{Genotype probabilities as calculated by

--- a/man/scan1perm.Rd
+++ b/man/scan1perm.Rd
@@ -85,17 +85,17 @@ stratified permutation test with the strata defined by the rows of
 \code{perm_strata} that is a vector containing a single repeated
 value.
 
-The \code{...} argument can contain three additional control
+The \code{...} argument can contain several additional control
 parameters; suspended for simplicity (or confusion, depending on
-your point of view). \code{tol} is used as a tolerance value for
-linear regression by QR decomposition (in determining whether
-columns are linearly dependent on others and should be omitted);
-default \code{1e-12}. \code{intcovar_method} indicates whether to
-use a high-memory (but potentially faster) method or a low-memory
-(and possibly slower) method, with values \code{"highmem"} or
-\code{"lowmem"}; default \code{"lowmem"}.  Finally, \code{max_batch}
-indicates the maximum number of phenotypes to run together; default
-is 1000.
+your point of view). \code{tol} is used as a tolerance value for linear
+regression by QR decomposition (in determining whether columns are
+linearly dependent on others and should be omitted); default
+\code{1e-12}. \code{maxit} is the maximum number of iteractions for
+converence of the iterative algorithm used when \code{model=binary}.
+\code{bintol} is used as a tolerance for converence for the iterative
+algorithm used when \code{model=binary}. \code{nu_max} is the maximum value
+for the "linear predictor" in the case \code{model="binary"} (a bit of a
+technicality to avoid fitted values exactly at 0 or 1).
 }
 \examples{
 # read data

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -32,8 +32,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // calc_ll_binreg_eigenchol
-double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol);
-RcppExport SEXP _qtl2_calc_ll_binreg_eigenchol(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP) {
+double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_eigenchol(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -41,13 +41,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const NumericVector& >::type y(ySEXP);
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_eigenchol(X, y, maxit, tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_eigenchol(X, y, maxit, tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg_eigenqr
-double calc_ll_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_ll_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+double calc_ll_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -56,13 +57,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_eigenqr(X, y, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coef_binreg_eigenqr
-NumericVector calc_coef_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_coef_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericVector calc_coef_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_coef_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -71,13 +73,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_eigenqr(X, y, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coefSE_binreg_eigenqr
-List calc_coefSE_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_coefSE_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List calc_coefSE_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_coefSE_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -86,13 +89,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_eigenqr(X, y, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit_binreg_eigenqr
-List fit_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const bool se, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_fit_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List fit_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_fit_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -102,13 +106,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit_binreg_eigenqr(X, y, se, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit_binreg_eigenqr(X, y, se, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg_weighted_eigenchol
-double calc_ll_binreg_weighted_eigenchol(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol);
-RcppExport SEXP _qtl2_calc_ll_binreg_weighted_eigenchol(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP) {
+double calc_ll_binreg_weighted_eigenchol(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_weighted_eigenchol(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -117,13 +122,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted_eigenchol(X, y, weights, maxit, tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted_eigenchol(X, y, weights, maxit, tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg_weighted_eigenqr
-double calc_ll_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_ll_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+double calc_ll_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -133,13 +139,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coef_binreg_weighted_eigenqr
-NumericVector calc_coef_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_coef_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericVector calc_coef_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_coef_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -149,13 +156,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coefSE_binreg_weighted_eigenqr
-List calc_coefSE_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_coefSE_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List calc_coefSE_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_coefSE_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -165,13 +173,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit_binreg_weighted_eigenqr
-List fit_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_fit_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List fit_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_fit_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -182,13 +191,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit_binreg_weighted_eigenqr(X, y, weights, se, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit_binreg_weighted_eigenqr(X, y, weights, se, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg_weighted
-double calc_ll_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_ll_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+double calc_ll_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -198,13 +208,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted(X, y, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted(X, y, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coef_binreg_weighted
-NumericVector calc_coef_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_coef_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericVector calc_coef_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_coef_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -214,13 +225,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_weighted(X, y, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_weighted(X, y, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coefSE_binreg_weighted
-List calc_coefSE_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_coefSE_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List calc_coefSE_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_coefSE_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -230,13 +242,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_weighted(X, y, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_weighted(X, y, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit_binreg_weighted
-List fit_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_fit_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List fit_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_fit_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -247,13 +260,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit_binreg_weighted(X, y, weights, se, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit_binreg_weighted(X, y, weights, se, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg
-double calc_ll_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_ll_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+double calc_ll_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_ll_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -262,13 +276,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg(X, y, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg(X, y, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coef_binreg
-NumericVector calc_coef_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_coef_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericVector calc_coef_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_coef_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -277,13 +292,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg(X, y, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg(X, y, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coefSE_binreg
-List calc_coefSE_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_calc_coefSE_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List calc_coefSE_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_calc_coefSE_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -292,13 +308,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg(X, y, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg(X, y, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit_binreg
-List fit_binreg(const NumericMatrix& X, const NumericVector& y, const bool se, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_fit_binreg(SEXP XSEXP, SEXP ySEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List fit_binreg(const NumericMatrix& X, const NumericVector& y, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_fit_binreg(SEXP XSEXP, SEXP ySEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -308,7 +325,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit_binreg(X, y, se, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit_binreg(X, y, se, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -579,8 +597,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // fit1_binary_addcovar
-List fit1_binary_addcovar(const NumericMatrix& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_fit1_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List fit1_binary_addcovar(const NumericMatrix& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_fit1_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -592,13 +610,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit1_binary_addcovar(genoprobs, pheno, addcovar, weights, se, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit1_binary_addcovar(genoprobs, pheno, addcovar, weights, se, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit1_binary_intcovar
-List fit1_binary_intcovar(const NumericMatrix& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_fit1_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List fit1_binary_intcovar(const NumericMatrix& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_fit1_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -611,7 +630,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit1_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, se, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit1_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, se, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1618,8 +1638,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // scan_binary_onechr
-NumericMatrix scan_binary_onechr(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_scan_binary_onechr(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericMatrix scan_binary_onechr(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_scan_binary_onechr(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1629,13 +1649,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr(genoprobs, pheno, addcovar, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr(genoprobs, pheno, addcovar, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scan_binary_onechr_weighted
-NumericMatrix scan_binary_onechr_weighted(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_scan_binary_onechr_weighted(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericMatrix scan_binary_onechr_weighted(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_scan_binary_onechr_weighted(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1646,7 +1667,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_weighted(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_weighted(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1686,8 +1708,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // scan_binary_onechr_intcovar_lowmem
-NumericMatrix scan_binary_onechr_intcovar_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_scan_binary_onechr_intcovar_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericMatrix scan_binary_onechr_intcovar_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_scan_binary_onechr_intcovar_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1698,13 +1720,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_intcovar_lowmem(genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_intcovar_lowmem(genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scan_binary_onechr_intcovar_weighted_lowmem
-NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_scan_binary_onechr_intcovar_weighted_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_scan_binary_onechr_intcovar_weighted_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1716,7 +1739,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_intcovar_weighted_lowmem(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_intcovar_weighted_lowmem(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1891,8 +1915,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // scancoef_binary_addcovar
-NumericMatrix scancoef_binary_addcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_scancoef_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericMatrix scancoef_binary_addcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_scancoef_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1903,13 +1927,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scancoef_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scancoef_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scancoef_binary_intcovar
-NumericMatrix scancoef_binary_intcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_scancoef_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+NumericMatrix scancoef_binary_intcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_scancoef_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1921,13 +1946,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scancoef_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scancoef_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scancoefSE_binary_addcovar
-List scancoefSE_binary_addcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_scancoefSE_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List scancoefSE_binary_addcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_scancoefSE_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1938,13 +1964,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scancoefSE_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scancoefSE_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scancoefSE_binary_intcovar
-List scancoefSE_binary_intcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol);
-RcppExport SEXP _qtl2_scancoefSE_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP) {
+List scancoefSE_binary_intcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
+RcppExport SEXP _qtl2_scancoefSE_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1956,7 +1983,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scancoefSE_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol));
+    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scancoefSE_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2371,24 +2399,24 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_qtl2_arrange_genes", (DL_FUNC) &_qtl2_arrange_genes, 2},
     {"_qtl2_R_bayes_int_plain", (DL_FUNC) &_qtl2_R_bayes_int_plain, 3},
-    {"_qtl2_calc_ll_binreg_eigenchol", (DL_FUNC) &_qtl2_calc_ll_binreg_eigenchol, 4},
-    {"_qtl2_calc_ll_binreg_eigenqr", (DL_FUNC) &_qtl2_calc_ll_binreg_eigenqr, 5},
-    {"_qtl2_calc_coef_binreg_eigenqr", (DL_FUNC) &_qtl2_calc_coef_binreg_eigenqr, 5},
-    {"_qtl2_calc_coefSE_binreg_eigenqr", (DL_FUNC) &_qtl2_calc_coefSE_binreg_eigenqr, 5},
-    {"_qtl2_fit_binreg_eigenqr", (DL_FUNC) &_qtl2_fit_binreg_eigenqr, 6},
-    {"_qtl2_calc_ll_binreg_weighted_eigenchol", (DL_FUNC) &_qtl2_calc_ll_binreg_weighted_eigenchol, 5},
-    {"_qtl2_calc_ll_binreg_weighted_eigenqr", (DL_FUNC) &_qtl2_calc_ll_binreg_weighted_eigenqr, 6},
-    {"_qtl2_calc_coef_binreg_weighted_eigenqr", (DL_FUNC) &_qtl2_calc_coef_binreg_weighted_eigenqr, 6},
-    {"_qtl2_calc_coefSE_binreg_weighted_eigenqr", (DL_FUNC) &_qtl2_calc_coefSE_binreg_weighted_eigenqr, 6},
-    {"_qtl2_fit_binreg_weighted_eigenqr", (DL_FUNC) &_qtl2_fit_binreg_weighted_eigenqr, 7},
-    {"_qtl2_calc_ll_binreg_weighted", (DL_FUNC) &_qtl2_calc_ll_binreg_weighted, 6},
-    {"_qtl2_calc_coef_binreg_weighted", (DL_FUNC) &_qtl2_calc_coef_binreg_weighted, 6},
-    {"_qtl2_calc_coefSE_binreg_weighted", (DL_FUNC) &_qtl2_calc_coefSE_binreg_weighted, 6},
-    {"_qtl2_fit_binreg_weighted", (DL_FUNC) &_qtl2_fit_binreg_weighted, 7},
-    {"_qtl2_calc_ll_binreg", (DL_FUNC) &_qtl2_calc_ll_binreg, 5},
-    {"_qtl2_calc_coef_binreg", (DL_FUNC) &_qtl2_calc_coef_binreg, 5},
-    {"_qtl2_calc_coefSE_binreg", (DL_FUNC) &_qtl2_calc_coefSE_binreg, 5},
-    {"_qtl2_fit_binreg", (DL_FUNC) &_qtl2_fit_binreg, 6},
+    {"_qtl2_calc_ll_binreg_eigenchol", (DL_FUNC) &_qtl2_calc_ll_binreg_eigenchol, 5},
+    {"_qtl2_calc_ll_binreg_eigenqr", (DL_FUNC) &_qtl2_calc_ll_binreg_eigenqr, 6},
+    {"_qtl2_calc_coef_binreg_eigenqr", (DL_FUNC) &_qtl2_calc_coef_binreg_eigenqr, 6},
+    {"_qtl2_calc_coefSE_binreg_eigenqr", (DL_FUNC) &_qtl2_calc_coefSE_binreg_eigenqr, 6},
+    {"_qtl2_fit_binreg_eigenqr", (DL_FUNC) &_qtl2_fit_binreg_eigenqr, 7},
+    {"_qtl2_calc_ll_binreg_weighted_eigenchol", (DL_FUNC) &_qtl2_calc_ll_binreg_weighted_eigenchol, 6},
+    {"_qtl2_calc_ll_binreg_weighted_eigenqr", (DL_FUNC) &_qtl2_calc_ll_binreg_weighted_eigenqr, 7},
+    {"_qtl2_calc_coef_binreg_weighted_eigenqr", (DL_FUNC) &_qtl2_calc_coef_binreg_weighted_eigenqr, 7},
+    {"_qtl2_calc_coefSE_binreg_weighted_eigenqr", (DL_FUNC) &_qtl2_calc_coefSE_binreg_weighted_eigenqr, 7},
+    {"_qtl2_fit_binreg_weighted_eigenqr", (DL_FUNC) &_qtl2_fit_binreg_weighted_eigenqr, 8},
+    {"_qtl2_calc_ll_binreg_weighted", (DL_FUNC) &_qtl2_calc_ll_binreg_weighted, 7},
+    {"_qtl2_calc_coef_binreg_weighted", (DL_FUNC) &_qtl2_calc_coef_binreg_weighted, 7},
+    {"_qtl2_calc_coefSE_binreg_weighted", (DL_FUNC) &_qtl2_calc_coefSE_binreg_weighted, 7},
+    {"_qtl2_fit_binreg_weighted", (DL_FUNC) &_qtl2_fit_binreg_weighted, 8},
+    {"_qtl2_calc_ll_binreg", (DL_FUNC) &_qtl2_calc_ll_binreg, 6},
+    {"_qtl2_calc_coef_binreg", (DL_FUNC) &_qtl2_calc_coef_binreg, 6},
+    {"_qtl2_calc_coefSE_binreg", (DL_FUNC) &_qtl2_calc_coefSE_binreg, 6},
+    {"_qtl2_fit_binreg", (DL_FUNC) &_qtl2_fit_binreg, 7},
     {"_qtl2_calc_kinship", (DL_FUNC) &_qtl2_calc_kinship, 1},
     {"_qtl2_crosstype_supported", (DL_FUNC) &_qtl2_crosstype_supported, 1},
     {"_qtl2_count_invalid_genotypes", (DL_FUNC) &_qtl2_count_invalid_genotypes, 5},
@@ -2410,8 +2438,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_qtl2_R_find_peaks", (DL_FUNC) &_qtl2_R_find_peaks, 3},
     {"_qtl2_R_find_peaks_and_lodint", (DL_FUNC) &_qtl2_R_find_peaks_and_lodint, 4},
     {"_qtl2_R_find_peaks_and_bayesint", (DL_FUNC) &_qtl2_R_find_peaks_and_bayesint, 5},
-    {"_qtl2_fit1_binary_addcovar", (DL_FUNC) &_qtl2_fit1_binary_addcovar, 8},
-    {"_qtl2_fit1_binary_intcovar", (DL_FUNC) &_qtl2_fit1_binary_intcovar, 9},
+    {"_qtl2_fit1_binary_addcovar", (DL_FUNC) &_qtl2_fit1_binary_addcovar, 9},
+    {"_qtl2_fit1_binary_intcovar", (DL_FUNC) &_qtl2_fit1_binary_intcovar, 10},
     {"_qtl2_fit1_hk_addcovar", (DL_FUNC) &_qtl2_fit1_hk_addcovar, 6},
     {"_qtl2_fit1_hk_intcovar", (DL_FUNC) &_qtl2_fit1_hk_intcovar, 7},
     {"_qtl2_fit1_pg_addcovar", (DL_FUNC) &_qtl2_fit1_pg_addcovar, 7},
@@ -2484,12 +2512,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"_qtl2_permute_nvector_stratified", (DL_FUNC) &_qtl2_permute_nvector_stratified, 4},
     {"_qtl2_permute_ivector_stratified", (DL_FUNC) &_qtl2_permute_ivector_stratified, 4},
     {"_qtl2_reduce_markers", (DL_FUNC) &_qtl2_reduce_markers, 3},
-    {"_qtl2_scan_binary_onechr", (DL_FUNC) &_qtl2_scan_binary_onechr, 6},
-    {"_qtl2_scan_binary_onechr_weighted", (DL_FUNC) &_qtl2_scan_binary_onechr_weighted, 7},
+    {"_qtl2_scan_binary_onechr", (DL_FUNC) &_qtl2_scan_binary_onechr, 7},
+    {"_qtl2_scan_binary_onechr_weighted", (DL_FUNC) &_qtl2_scan_binary_onechr_weighted, 8},
     {"_qtl2_scan_binary_onechr_intcovar_highmem", (DL_FUNC) &_qtl2_scan_binary_onechr_intcovar_highmem, 7},
     {"_qtl2_scan_binary_onechr_intcovar_weighted_highmem", (DL_FUNC) &_qtl2_scan_binary_onechr_intcovar_weighted_highmem, 8},
-    {"_qtl2_scan_binary_onechr_intcovar_lowmem", (DL_FUNC) &_qtl2_scan_binary_onechr_intcovar_lowmem, 7},
-    {"_qtl2_scan_binary_onechr_intcovar_weighted_lowmem", (DL_FUNC) &_qtl2_scan_binary_onechr_intcovar_weighted_lowmem, 8},
+    {"_qtl2_scan_binary_onechr_intcovar_lowmem", (DL_FUNC) &_qtl2_scan_binary_onechr_intcovar_lowmem, 8},
+    {"_qtl2_scan_binary_onechr_intcovar_weighted_lowmem", (DL_FUNC) &_qtl2_scan_binary_onechr_intcovar_weighted_lowmem, 9},
     {"_qtl2_scan_hk_onechr_nocovar", (DL_FUNC) &_qtl2_scan_hk_onechr_nocovar, 3},
     {"_qtl2_scan_hk_onechr", (DL_FUNC) &_qtl2_scan_hk_onechr, 4},
     {"_qtl2_scan_hk_onechr_weighted", (DL_FUNC) &_qtl2_scan_hk_onechr_weighted, 5},
@@ -2501,10 +2529,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_qtl2_scan_pg_onechr_intcovar_highmem", (DL_FUNC) &_qtl2_scan_pg_onechr_intcovar_highmem, 7},
     {"_qtl2_scan_pg_onechr_intcovar_lowmem", (DL_FUNC) &_qtl2_scan_pg_onechr_intcovar_lowmem, 7},
     {"_qtl2_scanblup", (DL_FUNC) &_qtl2_scanblup, 6},
-    {"_qtl2_scancoef_binary_addcovar", (DL_FUNC) &_qtl2_scancoef_binary_addcovar, 7},
-    {"_qtl2_scancoef_binary_intcovar", (DL_FUNC) &_qtl2_scancoef_binary_intcovar, 8},
-    {"_qtl2_scancoefSE_binary_addcovar", (DL_FUNC) &_qtl2_scancoefSE_binary_addcovar, 7},
-    {"_qtl2_scancoefSE_binary_intcovar", (DL_FUNC) &_qtl2_scancoefSE_binary_intcovar, 8},
+    {"_qtl2_scancoef_binary_addcovar", (DL_FUNC) &_qtl2_scancoef_binary_addcovar, 8},
+    {"_qtl2_scancoef_binary_intcovar", (DL_FUNC) &_qtl2_scancoef_binary_intcovar, 9},
+    {"_qtl2_scancoefSE_binary_addcovar", (DL_FUNC) &_qtl2_scancoefSE_binary_addcovar, 8},
+    {"_qtl2_scancoefSE_binary_intcovar", (DL_FUNC) &_qtl2_scancoefSE_binary_intcovar, 9},
     {"_qtl2_scancoef_hk_addcovar", (DL_FUNC) &_qtl2_scancoef_hk_addcovar, 5},
     {"_qtl2_scancoef_hk_intcovar", (DL_FUNC) &_qtl2_scancoef_hk_intcovar, 6},
     {"_qtl2_scancoefSE_hk_addcovar", (DL_FUNC) &_qtl2_scancoefSE_hk_addcovar, 5},

--- a/src/binreg.cpp
+++ b/src/binreg.cpp
@@ -14,9 +14,9 @@ using namespace Eigen;
 // [[Rcpp::export]]
 double calc_ll_binreg(const NumericMatrix& X, const NumericVector& y,
                       const int maxit=100, const double tol=1e-6,
-                      const double qr_tol=1e-12)
+                      const double qr_tol=1e-12, const double nu_max=30.0)
 {
-    return calc_ll_binreg_eigenqr(X, y, maxit, tol, qr_tol);
+    return calc_ll_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max);
 }
 
 // logistic regression
@@ -24,9 +24,9 @@ double calc_ll_binreg(const NumericMatrix& X, const NumericVector& y,
 // [[Rcpp::export]]
 NumericVector calc_coef_binreg(const NumericMatrix& X, const NumericVector& y,
                                const int maxit=100, const double tol=1e-6,
-                               const double qr_tol=1e-12)
+                               const double qr_tol=1e-12, const double nu_max=30.0)
 {
-    return calc_coef_binreg_eigenqr(X, y, maxit, tol, qr_tol);
+    return calc_coef_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max);
 }
 
 // logistic regression
@@ -34,9 +34,9 @@ NumericVector calc_coef_binreg(const NumericMatrix& X, const NumericVector& y,
 // [[Rcpp::export]]
 List calc_coefSE_binreg(const NumericMatrix& X, const NumericVector& y,
                         const int maxit=100, const double tol=1e-6,
-                        const double qr_tol=1e-12)
+                        const double qr_tol=1e-12, const double nu_max=30.0)
 {
-    return calc_coefSE_binreg_eigenqr(X, y, maxit, tol, qr_tol);
+    return calc_coefSE_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max);
 }
 
 // logistic regression
@@ -45,7 +45,7 @@ List calc_coefSE_binreg(const NumericMatrix& X, const NumericVector& y,
 List fit_binreg(const NumericMatrix& X, const NumericVector& y,
                 const bool se=true, // whether to include SEs
                 const int maxit=100, const double tol=1e-6,
-                const double qr_tol=1e-12)
+                const double qr_tol=1e-12, const double nu_max=30.0)
 {
-    return fit_binreg_eigenqr(X, y, se, maxit, tol, qr_tol);
+    return fit_binreg_eigenqr(X, y, se, maxit, tol, qr_tol, nu_max);
 }

--- a/src/binreg.h
+++ b/src/binreg.h
@@ -10,7 +10,8 @@ double calc_ll_binreg(const Rcpp::NumericMatrix& X,
                       const Rcpp::NumericVector& y,
                       const int maxit,
                       const double tol,
-                      const double qr_tol);
+                      const double qr_tol,
+                      const double nu_max);
 
 // logistic regression
 // return just the coefficients
@@ -18,7 +19,8 @@ Rcpp::NumericVector calc_coef_binreg(const Rcpp::NumericMatrix& X,
                                      const Rcpp::NumericVector& y,
                                      const int maxit,
                                      const double tol,
-                                     const double qr_tol);
+                                     const double qr_tol,
+                                     const double nu_max);
 
 // logistic regression
 // return the coefficients and SEs
@@ -26,7 +28,8 @@ Rcpp::List calc_coefSE_binreg(const Rcpp::NumericMatrix& X,
                               const Rcpp::NumericVector& y,
                               const int maxit,
                               const double tol,
-                              const double qr_tol);
+                              const double qr_tol,
+                              const double nu_max);
 
 // logistic regression
 // return (llik, individual contributions to llik, fitted probabilities, coef, SE
@@ -35,7 +38,8 @@ Rcpp::List fit_binreg(const Rcpp::NumericMatrix& X,
                       const bool se, // whether to include SEs
                       const int maxit,
                       const double tol,
-                      const double qr_tol);
+                      const double qr_tol,
+                      const double nu_max);
 
 
 #endif // BINREG_H

--- a/src/binreg_eigen.h
+++ b/src/binreg_eigen.h
@@ -6,42 +6,57 @@
 
 // logistic regression by "LLt" Cholesky decomposition
 // return just the log likelihood
+//
+// maxit = maximum number of iterations
+// tol = tolerance for convergence
+// nu_max = maximum value for linear predictor
 double calc_ll_binreg_eigenchol(const Rcpp::NumericMatrix& X,
                                 const Rcpp::NumericVector& y,
                                 const int maxit,
-                                const double tol);
+                                const double tol,
+                                const double nu_max);
 
 // logistic regression by Qr decomposition with column pivoting
 // return just the log likelihood
+//
+// maxit = maximum number of iterations
+// tol = tolerance for convergence
+// qr_tol = tolerance for QR decomposition
+// nu_max = maximum value for linear predictor
+//
 double calc_ll_binreg_eigenqr(const Rcpp::NumericMatrix& X,
                               const Rcpp::NumericVector& y,
                               const int maxit,
                               const double tol,
-                              const double qr_tol);
+                              const double qr_tol,
+                              const double nu_max);
 
 // logistic regression
 // return just the coefficients
 Rcpp::NumericVector calc_coef_binreg_eigenqr(const Rcpp::NumericMatrix& X,
                                              const Rcpp::NumericVector& y,
-                                             const int maxit,
-                                             const double tol,
-                                             const double qr_tol);
+                                             const int maxit,      // max iterations
+                                             const double tol,     // tolerance for convergence
+                                             const double qr_tol,  // tolerance for QR decomp
+                                             const double nu_max); // max value for linear predictor
 
 // logistic regression
 // return the coefficients and SEs
 Rcpp::List calc_coefSE_binreg_eigenqr(const Rcpp::NumericMatrix& X,
                                       const Rcpp::NumericVector& y,
-                                      const int maxit,
-                                      const double tol,
-                                      const double qr_tol);
+                                      const int maxit,      // max iterations
+                                      const double tol,     // tolerance for convergence
+                                      const double qr_tol,  // tolerance for QR decomp
+                                      const double nu_max); // max value for linear predictor
 
 // logistic regression
 // return (llik, individual contributions to llik, fitted probabilities, coef, SE
 Rcpp::List fit_binreg_eigenqr(const Rcpp::NumericMatrix& X,
                               const Rcpp::NumericVector& y,
-                              const bool se, // whether to include SEs
-                              const int maxit,
-                              const double tol,
-                              const double qr_tol);
+                              const bool se,        // whether to include SEs
+                              const int maxit,      // max iterations
+                              const double tol,     // tolerance for convergence
+                              const double qr_tol,  // tolerance for QR decomp
+                              const double nu_max); // max value for linear predictor
 
 #endif // BINREG_EIGEN_H

--- a/src/binreg_weighted.cpp
+++ b/src/binreg_weighted.cpp
@@ -16,9 +16,9 @@ using namespace Eigen;
 double calc_ll_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
                                const NumericVector &weights,
                                const int maxit=100, const double tol=1e-6,
-                               const double qr_tol=1e-12)
+                               const double qr_tol=1e-12, const double nu_max=30.0)
 {
-    return calc_ll_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol);
+    return calc_ll_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max);
 }
 
 // logistic regression
@@ -28,9 +28,9 @@ double calc_ll_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
 NumericVector calc_coef_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
                                         const NumericVector &weights,
                                         const int maxit=100, const double tol=1e-6,
-                                        const double qr_tol=1e-12)
+                                        const double qr_tol=1e-12, const double nu_max=30.0)
 {
-    return calc_coef_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol);
+    return calc_coef_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max);
 }
 
 // logistic regression
@@ -40,9 +40,9 @@ NumericVector calc_coef_binreg_weighted(const NumericMatrix& X, const NumericVec
 List calc_coefSE_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
                                  const NumericVector &weights,
                                  const int maxit=100, const double tol=1e-6,
-                                 const double qr_tol=1e-12)
+                                 const double qr_tol=1e-12, const double nu_max=30.0)
 {
-    return calc_coefSE_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol);
+    return calc_coefSE_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max);
 }
 
 // logistic regression
@@ -53,7 +53,7 @@ List fit_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
                          const NumericVector &weights,
                          const bool se=true, // whether to include SEs
                          const int maxit=100, const double tol=1e-6,
-                         const double qr_tol=1e-12)
+                         const double qr_tol=1e-12, const double nu_max=30.0)
 {
-    return fit_binreg_weighted_eigenqr(X, y, weights, se, maxit, tol, qr_tol);
+    return fit_binreg_weighted_eigenqr(X, y, weights, se, maxit, tol, qr_tol, nu_max);
 }

--- a/src/binreg_weighted.h
+++ b/src/binreg_weighted.h
@@ -12,7 +12,8 @@ double calc_ll_binreg_weighted(const Rcpp::NumericMatrix& X,
                                const Rcpp::NumericVector &weights,
                                const int maxit,
                                const double tol,
-                               const double qr_tol);
+                               const double qr_tol,
+                               const double nu_max);
 
 // logistic regression
 // return just the coefficients
@@ -22,7 +23,8 @@ Rcpp::NumericVector calc_coef_binreg_weighted(const Rcpp::NumericMatrix& X,
                                               const Rcpp::NumericVector &weights,
                                               const int maxit,
                                               const double tol,
-                                              const double qr_tol);
+                                              const double qr_tol,
+                                              const double nu_max);
 
 // logistic regression
 // return the coefficients and SEs
@@ -32,7 +34,8 @@ Rcpp::List calc_coefSE_binreg_weighted(const Rcpp::NumericMatrix& X,
                                        const Rcpp::NumericVector &weights,
                                        const int maxit,
                                        const double tol,
-                                       const double qr_tol);
+                                       const double qr_tol,
+                                       const double nu_max);
 
 // logistic regression
 // return (llik, individual contributions to llik, fitted probabilities, coef, SE
@@ -43,6 +46,7 @@ Rcpp::List fit_binreg_weighted(const Rcpp::NumericMatrix& X,
                                const bool se, // whether to include SEs
                                const int maxit,
                                const double tol,
-                               const double qr_tol);
+                               const double qr_tol,
+                               const double nu_max);
 
 #endif // BINREG_WEIGHTED_H

--- a/src/binreg_weighted_eigen.cpp
+++ b/src/binreg_weighted_eigen.cpp
@@ -18,10 +18,9 @@ using namespace Eigen;
 // [[Rcpp::export]]
 double calc_ll_binreg_weighted_eigenchol(const NumericMatrix& X, const NumericVector& y,
                                          const NumericVector &weights,
-                                         const int maxit=100, const double tol=1e-6)
+                                         const int maxit=100, const double tol=1e-6,
+                                         const double nu_max=30.0)
 {
-    const double nu_tol = 100.0; // maximum allowed value on linear predictor
-
     const int n_ind = y.size();
     #ifndef RQTL2_NODEBUG
     if(n_ind != X.rows())
@@ -57,8 +56,8 @@ double calc_ll_binreg_weighted_eigenchol(const NumericMatrix& X, const NumericVe
             nu[ind] /= wt[ind]; // need to divide by previous weights
 
             // don't let nu get too large or too small
-            if(nu[ind] < -nu_tol) nu[ind] = -nu_tol;
-            else if(nu[ind] > nu_tol) nu[ind] = nu_tol;
+            if(nu[ind] < -nu_max) nu[ind] = -nu_max;
+            else if(nu[ind] > nu_max) nu[ind] = nu_max;
 
             pi[ind] = exp(nu[ind])/(1.0 + exp(nu[ind]));
 
@@ -90,10 +89,9 @@ double calc_ll_binreg_weighted_eigenchol(const NumericMatrix& X, const NumericVe
 double calc_ll_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y,
                                        const NumericVector& weights,
                                        const int maxit=100, const double tol=1e-6,
-                                       const double qr_tol=1e-12)
+                                       const double qr_tol=1e-12,
+                                       const double nu_max=30.0)
 {
-    const double nu_tol = 100.0; // maximum allowed value on linear predictor
-
     const int n_ind = y.size();
     #ifndef RQTL2_NODEBUG
     if(n_ind != X.rows())
@@ -129,8 +127,8 @@ double calc_ll_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVect
             nu[ind] /= wt[ind]; // need to divide by previous weights
 
             // don't let nu get too large or too small
-            if(nu[ind] < -nu_tol) nu[ind] = -nu_tol;
-            else if(nu[ind] > nu_tol) nu[ind] = nu_tol;
+            if(nu[ind] < -nu_max) nu[ind] = -nu_max;
+            else if(nu[ind] > nu_max) nu[ind] = nu_max;
 
             pi[ind] = exp(nu[ind])/(1.0 + exp(nu[ind]));
 
@@ -163,9 +161,10 @@ NumericVector calc_coef_binreg_weighted_eigenqr(const NumericMatrix& X,
                                                 const NumericVector& weights,
                                                 const int maxit=100,
                                                 const double tol=1e-6,
-                                                const double qr_tol=1e-12)
+                                                const double qr_tol=1e-12,
+                                                const double nu_max=30.0)
 {
-    List fit = fit_binreg_weighted_eigenqr(X, y, weights, false, maxit, tol, qr_tol);
+    List fit = fit_binreg_weighted_eigenqr(X, y, weights, false, maxit, tol, qr_tol, nu_max);
 
     NumericVector coef = fit[2];
     return(coef);
@@ -180,9 +179,10 @@ List calc_coefSE_binreg_weighted_eigenqr(const NumericMatrix& X,
                                          const NumericVector & weights,
                                          const int maxit=100,
                                          const double tol=1e-6,
-                                         const double qr_tol=1e-12)
+                                         const double qr_tol=1e-12,
+                                         const double nu_max=30.0)
 {
-    List fit = fit_binreg_weighted_eigenqr(X, y, weights, true, maxit, tol, qr_tol);
+    List fit = fit_binreg_weighted_eigenqr(X, y, weights, true, maxit, tol, qr_tol, nu_max);
 
     NumericVector coef = fit[2];
     NumericVector SE = fit[3];
@@ -201,10 +201,9 @@ List fit_binreg_weighted_eigenqr(const NumericMatrix& X,
                                  const bool se=true, // whether to include SEs
                                  const int maxit=100,
                                  const double tol=1e-6,
-                                 const double qr_tol=1e-12)
+                                 const double qr_tol=1e-12,
+                                 const double nu_max=30.0)
 {
-    const double nu_tol = 100.0; // maximum allowed value on linear predictor
-
     const int n_ind = y.size();
     #ifndef RQTL2_NODEBUG
     if(n_ind != X.rows())
@@ -240,8 +239,8 @@ List fit_binreg_weighted_eigenqr(const NumericMatrix& X,
             nu[ind] /= wt[ind]; // need to divide by previous weights
 
             // don't let nu get too large or too small
-            if(nu[ind] < -nu_tol) nu[ind] = -nu_tol;
-            else if(nu[ind] > nu_tol) nu[ind] = nu_tol;
+            if(nu[ind] < -nu_max) nu[ind] = -nu_max;
+            else if(nu[ind] > nu_max) nu[ind] = nu_max;
 
             pi[ind] = exp(nu[ind])/(1.0 + exp(nu[ind]));
 

--- a/src/binreg_weighted_eigen.h
+++ b/src/binreg_weighted_eigen.h
@@ -11,7 +11,8 @@ double calc_ll_binreg_weighted_eigenchol(const Rcpp::NumericMatrix& X,
                                          const Rcpp::NumericVector& y,
                                          const Rcpp::NumericVector& weights,
                                          const int maxit,
-                                         const double tol);
+                                         const double tol,
+                                         const double nu_max);
 
 // logistic regression by Qr decomposition with column pivoting
 // return just the log likelihood
@@ -21,7 +22,8 @@ double calc_ll_binreg_weighted_eigenqr(const Rcpp::NumericMatrix& X,
                                        const Rcpp::NumericVector& weights,
                                        const int maxit,
                                        const double tol,
-                                       const double qr_tol);
+                                       const double qr_tol,
+                                       const double nu_max);
 
 // logistic regression
 // return just the coefficients
@@ -31,7 +33,8 @@ Rcpp::NumericVector calc_coef_binreg_weighted_eigenqr(const Rcpp::NumericMatrix&
                                                       const Rcpp::NumericVector& weights,
                                                       const int maxit,
                                                       const double tol,
-                                                      const double qr_tol);
+                                                      const double qr_tol,
+                                                      const double nu_max);
 
 // logistic regression
 // return the coefficients and SEs
@@ -41,7 +44,8 @@ Rcpp::List calc_coefSE_binreg_weighted_eigenqr(const Rcpp::NumericMatrix& X,
                                                const Rcpp::NumericVector& weights,
                                                const int maxit,
                                                const double tol,
-                                               const double qr_tol);
+                                               const double qr_tol,
+                                               const double nu_max);
 
 // logistic regression
 // return (llik, individual contributions to llik, fitted probabilities, coef, SE
@@ -52,6 +56,7 @@ Rcpp::List fit_binreg_weighted_eigenqr(const Rcpp::NumericMatrix& X,
                                        const bool se, // whether to include SEs
                                        const int maxit,
                                        const double tol,
-                                       const double qr_tol);
+                                       const double qr_tol,
+                                       const double nu_max);
 
 #endif // BINREG_WEIGHTED_EIGEN_H

--- a/src/fit1_binary.cpp
+++ b/src/fit1_binary.cpp
@@ -27,7 +27,8 @@ List fit1_binary_addcovar(const NumericMatrix& genoprobs,
                           const bool se=false,
                           const int maxit=100,
                           const double tol=1e-6,
-                          const double qr_tol=1e-12)
+                          const double qr_tol=1e-12,
+                          const double nu_max=30.0)
 {
     const int n_ind = pheno.size();
     const int n_gen = genoprobs.cols();
@@ -53,9 +54,9 @@ List fit1_binary_addcovar(const NumericMatrix& genoprobs,
         std::copy(addcovar.begin(), addcovar.end(), X.begin() + x_size);
 
     if(n_weights > 0)
-        return fit_binreg_weighted(X, pheno, weights, se, maxit, tol, qr_tol);
+        return fit_binreg_weighted(X, pheno, weights, se, maxit, tol, qr_tol, nu_max);
     else
-        return fit_binreg(X, pheno, se, maxit, tol, qr_tol);
+        return fit_binreg(X, pheno, se, maxit, tol, qr_tol, nu_max);
 }
 
 
@@ -79,7 +80,8 @@ List fit1_binary_intcovar(const NumericMatrix& genoprobs,
                           const bool se=true,
                           const int maxit=100,
                           const double tol=1e-6,
-                          const double qr_tol=1e-12)
+                          const double qr_tol=1e-12,
+                          const double nu_max=30.0)
 {
     const int n_ind = pheno.size();
     const int n_weights = weights.size();
@@ -97,7 +99,7 @@ List fit1_binary_intcovar(const NumericMatrix& genoprobs,
     NumericMatrix X = formX_intcovar(genoprobs, addcovar, intcovar, 0, false);
 
     if(n_weights > 0)
-        return fit_binreg_weighted(X, pheno, weights, se, maxit, tol, qr_tol);
+        return fit_binreg_weighted(X, pheno, weights, se, maxit, tol, qr_tol, nu_max);
     else
-        return fit_binreg(X, pheno, se, maxit, tol, qr_tol);
+        return fit_binreg(X, pheno, se, maxit, tol, qr_tol, nu_max);
 }

--- a/src/fit1_binary.h
+++ b/src/fit1_binary.h
@@ -20,7 +20,8 @@ Rcpp::List fit1_binary_addcovar(const Rcpp::NumericMatrix& genoprobs,
                                 const bool se,
                                 const int maxit,
                                 const double tol,
-                                const double qr_tol);
+                                const double qr_tol,
+                                const double nu_max);
 
 
 // Fit a single-QTL model at a single position, with interactive covariates
@@ -39,6 +40,7 @@ Rcpp::List fit1_binary_intcovar(const Rcpp::NumericMatrix& genoprobs,
                                 const bool se,
                                 const int maxit,
                                 const double tol,
-                                const double qr_tol);
+                                const double qr_tol,
+                                const double nu_max);
 
 #endif // FIT1_BINARY_H

--- a/src/scan1_binary.cpp
+++ b/src/scan1_binary.cpp
@@ -25,7 +25,8 @@ NumericMatrix scan_binary_onechr(const NumericVector& genoprobs,
                                  const NumericMatrix& addcovar,
                                  const int maxit=100,
                                  const double tol=1e-6,
-                                 const double qr_tol=1e-12)
+                                 const double qr_tol=1e-12,
+                                 const double nu_max=30.0)
 {
     const int n_ind = pheno.rows();
     const int n_phe = pheno.cols();
@@ -57,7 +58,7 @@ NumericMatrix scan_binary_onechr(const NumericVector& genoprobs,
 
         for(int phe=0; phe<n_phe; phe++) {
             // calc rss and paste into ith column of result
-            result(phe,pos) = calc_ll_binreg(X, pheno(_,phe), maxit, tol, qr_tol);
+            result(phe,pos) = calc_ll_binreg(X, pheno(_,phe), maxit, tol, qr_tol, nu_max);
         }
     }
 
@@ -81,7 +82,8 @@ NumericMatrix scan_binary_onechr_weighted(const NumericVector& genoprobs,
                                           const NumericVector& weights,
                                           const int maxit=100,
                                           const double tol=1e-6,
-                                          const double qr_tol=1e-12)
+                                          const double qr_tol=1e-12,
+                                          const double nu_max=30.0)
 {
     const int n_ind = pheno.rows();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -115,7 +117,7 @@ NumericMatrix scan_binary_onechr_weighted(const NumericVector& genoprobs,
 
         for(int phe=0; phe<n_phe; phe++) {
             // calc rss and paste into ith column of result
-            result(phe,pos) = calc_ll_binreg_weighted(X, pheno(_,phe), weights, maxit, tol, qr_tol);
+            result(phe,pos) = calc_ll_binreg_weighted(X, pheno(_,phe), weights, maxit, tol, qr_tol, nu_max);
         }
     }
 
@@ -228,7 +230,8 @@ NumericMatrix scan_binary_onechr_intcovar_lowmem(const NumericVector& genoprobs,
                                                  const NumericMatrix& intcovar,
                                                  const int maxit=100,
                                                  const double tol=1e-6,
-                                                 const double qr_tol=1e-12)
+                                                 const double qr_tol=1e-12,
+                                                 const double nu_max=30.0)
 {
     const int n_ind = pheno.rows();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -255,7 +258,7 @@ NumericMatrix scan_binary_onechr_intcovar_lowmem(const NumericVector& genoprobs,
 
         for(int phe=0; phe<n_phe; phe++) {
             // do regression
-            result(phe,pos) = calc_ll_binreg(X, pheno(_,phe), maxit, tol, qr_tol);
+            result(phe,pos) = calc_ll_binreg(X, pheno(_,phe), maxit, tol, qr_tol, nu_max);
         }
     }
 
@@ -284,7 +287,8 @@ NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const NumericVector& g
                                                           const NumericVector& weights,
                                                           const int maxit=100,
                                                           const double tol=1e-6,
-                                                          const double qr_tol=1e-12)
+                                                          const double qr_tol=1e-12,
+                                                          const double nu_max=30.0)
 {
     const int n_ind = pheno.rows();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -311,7 +315,7 @@ NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const NumericVector& g
 
         for(int phe=0; phe<n_phe; phe++) {
             // do regression
-            result(phe,pos) = calc_ll_binreg_weighted(X, pheno(_,phe), weights, maxit, tol, qr_tol);
+            result(phe,pos) = calc_ll_binreg_weighted(X, pheno(_,phe), weights, maxit, tol, qr_tol, nu_max);
         }
     }
 

--- a/src/scan1_binary.h
+++ b/src/scan1_binary.h
@@ -17,7 +17,8 @@ Rcpp::NumericMatrix scan_binary_onechr(const Rcpp::NumericVector& genoprobs,
                                        const Rcpp::NumericMatrix& addcovar,
                                        const int maxit,
                                        const double tol,
-                                       const double qr_tol);
+                                       const double qr_tol,
+                                       const double nu_max);
 
 // Scan a single chromosome with additive covariates and weights
 //
@@ -34,7 +35,8 @@ Rcpp::NumericMatrix scan_binary_onechr_weighted(const Rcpp::NumericVector& genop
                                                 const Rcpp::NumericVector& weights,
                                                 const int maxit,
                                                 const double tol,
-                                                const double qr_tol);
+                                                const double qr_tol,
+                                                const double nu_max);
 
 // Scan a single chromosome with interactive covariates
 // this version should be fast but requires more memory
@@ -48,12 +50,13 @@ Rcpp::NumericMatrix scan_binary_onechr_weighted(const Rcpp::NumericVector& genop
 //
 // output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
 Rcpp::NumericMatrix scan_binary_onechr_intcovar_highmem(const Rcpp::NumericVector& genoprobs,
-                                                  const Rcpp::NumericMatrix& pheno,
-                                                  const Rcpp::NumericMatrix& addcovar,
-                                                  const Rcpp::NumericMatrix& intcovar,
-                                                  const int maxit,
-                                                  const double tol,
-                                                  const double qr_tol);
+                                                        const Rcpp::NumericMatrix& pheno,
+                                                        const Rcpp::NumericMatrix& addcovar,
+                                                        const Rcpp::NumericMatrix& intcovar,
+                                                        const int maxit,
+                                                        const double tol,
+                                                        const double qr_tol,
+                                                        const double nu_max);
 
 // Scan a single chromosome with interactive covariates
 // this version should be fast but requires more memory
@@ -74,7 +77,8 @@ Rcpp::NumericMatrix scan_binary_onechr_intcovar_weighted_highmem(const Rcpp::Num
                                                                  const Rcpp::NumericVector& weights,
                                                                  const int maxit,
                                                                  const double tol,
-                                                                 const double qr_tol);
+                                                                 const double qr_tol,
+                                                                 const double nu_max);
 
 // Scan a single chromosome with interactive covariates
 // this version uses less memory but will be slower
@@ -93,7 +97,8 @@ Rcpp::NumericMatrix scan_binary_onechr_intcovar_lowmem(const Rcpp::NumericVector
                                                        const Rcpp::NumericMatrix& intcovar,
                                                        const int maxit,
                                                        const double tol,
-                                                       const double qr_tol);
+                                                       const double qr_tol,
+                                                       const double nu_max);
 
 // Scan a single chromosome with interactive covariates
 // this version uses less memory but will be slower
@@ -115,6 +120,7 @@ Rcpp::NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const Rcpp::Nume
                                                                 const Rcpp::NumericVector& weights,
                                                                 const int maxit,
                                                                 const double tol,
-                                                                const double qr_tol);
+                                                                const double qr_tol,
+                                                                const double nu_max);
 
 #endif // SCAN_BINARY_H

--- a/src/scan1coef_binary.cpp
+++ b/src/scan1coef_binary.cpp
@@ -26,7 +26,8 @@ NumericMatrix scancoef_binary_addcovar(const NumericVector& genoprobs,
                                        const NumericVector& weights,
                                        const int maxit=100,
                                        const double tol=1e-6,
-                                       const double qr_tol=1e-12)
+                                       const double qr_tol=1e-12,
+                                       const double nu_max=30.0)
 {
     const int n_ind = pheno.size();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -63,9 +64,9 @@ NumericMatrix scancoef_binary_addcovar(const NumericVector& genoprobs,
 
         // do regression
         if(n_weights > 0)
-            result(_,pos) = calc_coef_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol);
+            result(_,pos) = calc_coef_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, nu_max);
         else
-            result(_,pos) = calc_coef_binreg(X, pheno, maxit, tol, qr_tol);
+            result(_,pos) = calc_coef_binreg(X, pheno, maxit, tol, qr_tol, nu_max);
     }
 
     return result;
@@ -91,7 +92,8 @@ NumericMatrix scancoef_binary_intcovar(const NumericVector& genoprobs,
                                        const NumericVector& weights,
                                        const int maxit=100,
                                        const double tol=1e-6,
-                                       const double qr_tol=1e-12)
+                                       const double qr_tol=1e-12,
+                                       const double nu_max=30.0)
 {
     const int n_ind = pheno.size();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -124,9 +126,9 @@ NumericMatrix scancoef_binary_intcovar(const NumericVector& genoprobs,
 
         // do regression
         if(n_weights > 0)
-            result(_,pos) = calc_coef_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol);
+            result(_,pos) = calc_coef_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, nu_max);
         else
-            result(_,pos) = calc_coef_binreg(X, pheno, maxit, tol, qr_tol);
+            result(_,pos) = calc_coef_binreg(X, pheno, maxit, tol, qr_tol, nu_max);
     }
 
     return result;
@@ -150,7 +152,8 @@ List scancoefSE_binary_addcovar(const NumericVector& genoprobs,
                                 const NumericVector& weights,
                                 const int maxit=100,
                                 const double tol=1e-6,
-                                const double qr_tol=1e-12)
+                                const double qr_tol=1e-12,
+                                const double nu_max=30.0)
 {
     const int n_ind = pheno.size();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -189,9 +192,9 @@ List scancoefSE_binary_addcovar(const NumericVector& genoprobs,
         // do regression
         List tmp;
         if(n_weights > 0)
-            tmp = calc_coefSE_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol);
+            tmp = calc_coefSE_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, nu_max);
         else
-            tmp = calc_coefSE_binreg(X, pheno, maxit, tol, qr_tol);
+            tmp = calc_coefSE_binreg(X, pheno, maxit, tol, qr_tol, nu_max);
         NumericVector tmpcoef = tmp[0];
         NumericVector tmpse = tmp[1];
         coef(_,pos) = tmpcoef;
@@ -222,7 +225,8 @@ List scancoefSE_binary_intcovar(const NumericVector& genoprobs,
                                 const NumericVector& weights,
                                 const int maxit=100,
                                 const double tol=1e-6,
-                                const double qr_tol=1e-12)
+                                const double qr_tol=1e-12,
+                                const double nu_max=30.0)
 {
     const int n_ind = pheno.size();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -257,9 +261,9 @@ List scancoefSE_binary_intcovar(const NumericVector& genoprobs,
         // do regression
         List tmp;
         if(n_weights > 0)
-            tmp = calc_coefSE_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol);
+            tmp = calc_coefSE_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, nu_max);
         else
-            tmp = calc_coefSE_binreg(X, pheno, maxit, tol, qr_tol);
+            tmp = calc_coefSE_binreg(X, pheno, maxit, tol, qr_tol, nu_max);
         NumericVector tmpcoef = tmp[0];
         NumericVector tmpse = tmp[1];
         coef(_,pos) = tmpcoef;

--- a/src/scan1coef_binary.h
+++ b/src/scan1coef_binary.h
@@ -19,7 +19,8 @@ Rcpp::NumericMatrix scancoef_binary_addcovar(const Rcpp::NumericVector& genoprob
                                              const Rcpp::NumericVector& weights,
                                              const int maxit,
                                              const double tol,
-                                             const double qr_tol);
+                                             const double qr_tol,
+                                             const double nu_max);
 
 // Scan a single chromosome to calculate coefficients, with interactive covariates
 //
@@ -38,7 +39,8 @@ Rcpp::NumericMatrix scancoef_binary_intcovar(const Rcpp::NumericVector& genoprob
                                              const Rcpp::NumericVector& weights,
                                              const int maxit,
                                              const double tol,
-                                             const double qr_tol);
+                                             const double qr_tol,
+                                             const double nu_max);
 
 // Scan a single chromosome to calculate coefficients, with additive covariates
 //
@@ -55,7 +57,8 @@ Rcpp::List scancoefSE_binary_addcovar(const Rcpp::NumericVector& genoprobs,
                                       const Rcpp::NumericVector& weights,
                                       const int maxit,
                                       const double tol,
-                                      const double qr_tol);
+                                      const double qr_tol,
+                                      const double nu_max);
 
 
 // Scan a single chromosome to calculate coefficients, with interactive covariates
@@ -75,6 +78,7 @@ Rcpp::List scancoefSE_binary_intcovar(const Rcpp::NumericVector& genoprobs,
                                       const Rcpp::NumericVector& weights,
                                       const int maxit,
                                       const double tol,
-                                      const double qr_tol);
+                                      const double qr_tol,
+                                      const double nu_max);
 
 #endif // SCAN1COEF_BINARY_H

--- a/tests/testthat/test-fit1_binary.R
+++ b/tests/testthat/test-fit1_binary.R
@@ -336,7 +336,7 @@ test_that("fit one for binary traits handles NA case", {
     suppressWarnings(ll1b <- glm(phe ~ -1 + p2, family=binomial(link=logit))$deviance)
     ll0 <- glm(phe ~ 1, family=binomial(link=logit))$deviance
 
-    expect_equal(out[mar[1],1], (ll0-ll1a)/2/log(10))
+    expect_equal(out[mar[1],1], (ll0-ll1a)/2/log(10), tol=1e-7)
     expect_equal(out[mar[2],1], (ll0-ll1b)/2/log(10), tol=1e-7)
 
     # repeat with weights
@@ -348,7 +348,7 @@ test_that("fit one for binary traits handles NA case", {
     suppressWarnings(ll1b_w <- glm(phe ~ -1 + p2, family=binomial(link=logit), weights=w)$deviance)
     suppressWarnings(ll0_w <- glm(phe ~ 1, family=binomial(link=logit), weights=w)$deviance)
 
-    expect_equal(outw[mar[1],1], (ll0_w-ll1a_w)/2/log(10))
+    expect_equal(outw[mar[1],1], (ll0_w-ll1a_w)/2/log(10), tol=1e-7)
     expect_equal(outw[mar[2],1], (ll0_w-ll1b_w)/2/log(10), tol=1e-7)
 
 })

--- a/tests/testthat/test-scan1snps.R
+++ b/tests/testthat/test-scan1snps.R
@@ -4,6 +4,9 @@ test_that("scan1snps works", {
 
     if(isnt_karl()) skip("this test only run locally")
 
+    RNGkind("Mersenne-Twister") # make sure we're using the standard RNG
+    set.seed(20180720)
+
     # load example data and calculate genotype probabilities
     file <- paste0("https://raw.githubusercontent.com/rqtl/",
                    "qtl2data/master/DOex/DOex.zip")
@@ -126,10 +129,8 @@ test_that("scan1snps works", {
     binphe <- setNames((DOex$pheno > quantile(DOex$pheno, 0.8, na.rm=TRUE))*1, rownames(DOex$pheno))
     biny <- binphe[rownames(p)]
 
-    expect_warning(  # warning about lack of convergence
-        outbin <- scan1snps(probs, DOex$pmap, binphe, query_func=queryf, chr=2, start=97.2, end=97.3,
-                            model="binary")
-    )
+    outbin <- scan1snps(probs, DOex$pmap, binphe, query_func=queryf, chr=2, start=97.2, end=97.3,
+                        model="binary")
 
     out_glm <- glm(biny ~ -1 + p, family=binomial(link=logit))
     out_glm0 <- glm(biny ~ 1, family=binomial(link=logit))
@@ -137,10 +138,8 @@ test_that("scan1snps works", {
 
     # binary trait with weights
     w <- ceiling(w) # avoid warning from glm() about weights not being integers
-    expect_warning(  # warning about lack of convergence
-        outbinw <- scan1snps(probs, DOex$pmap, binphe, query_func=queryf, chr=2, start=97.2, end=97.3,
-                             model="binary", weights=w)
-    )
+    outbinw <- scan1snps(probs, DOex$pmap, binphe, query_func=queryf, chr=2, start=97.2, end=97.3,
+                         model="binary", weights=w, nu_max=25, maxit=1000, tol=1e-5)
 
     out_glm <- glm(biny ~ -1 + p, family=binomial(link=logit), weights=w)
     out_glm0 <- glm(biny ~ 1, family=binomial(link=logit), weights=w)


### PR DESCRIPTION
- nu_max an argument passed down from fit1, scan1, scan1perm,
  scan1coef

- fit1 no longer has tol and maxit arguments, but rather ... which
  takes any hidden control parameters (included tol and maxit)