### PR TITLE
Change nu to eta and nu_max to eta_max throughout

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,76 +9,76 @@ arrange_genes <- function(start, end) {
     .Call(`_qtl2_R_bayes_int_plain`, lod, pos, prob)
 }
 
-calc_ll_binreg_eigenchol <- function(X, y, maxit = 100L, tol = 1e-6, nu_max = 30.0) {
-    .Call(`_qtl2_calc_ll_binreg_eigenchol`, X, y, maxit, tol, nu_max)
+calc_ll_binreg_eigenchol <- function(X, y, maxit = 100L, tol = 1e-6, eta_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_eigenchol`, X, y, maxit, tol, eta_max)
 }
 
-calc_ll_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_ll_binreg_eigenqr`, X, y, maxit, tol, qr_tol, nu_max)
+calc_ll_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_eigenqr`, X, y, maxit, tol, qr_tol, eta_max)
 }
 
-calc_coef_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_coef_binreg_eigenqr`, X, y, maxit, tol, qr_tol, nu_max)
+calc_coef_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_coef_binreg_eigenqr`, X, y, maxit, tol, qr_tol, eta_max)
 }
 
-calc_coefSE_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_coefSE_binreg_eigenqr`, X, y, maxit, tol, qr_tol, nu_max)
+calc_coefSE_binreg_eigenqr <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_coefSE_binreg_eigenqr`, X, y, maxit, tol, qr_tol, eta_max)
 }
 
-fit_binreg_eigenqr <- function(X, y, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_fit_binreg_eigenqr`, X, y, se, maxit, tol, qr_tol, nu_max)
+fit_binreg_eigenqr <- function(X, y, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_fit_binreg_eigenqr`, X, y, se, maxit, tol, qr_tol, eta_max)
 }
 
-calc_ll_binreg_weighted_eigenchol <- function(X, y, weights, maxit = 100L, tol = 1e-6, nu_max = 30.0) {
-    .Call(`_qtl2_calc_ll_binreg_weighted_eigenchol`, X, y, weights, maxit, tol, nu_max)
+calc_ll_binreg_weighted_eigenchol <- function(X, y, weights, maxit = 100L, tol = 1e-6, eta_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_weighted_eigenchol`, X, y, weights, maxit, tol, eta_max)
 }
 
-calc_ll_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_ll_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, nu_max)
+calc_ll_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, eta_max)
 }
 
-calc_coef_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_coef_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, nu_max)
+calc_coef_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_coef_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, eta_max)
 }
 
-calc_coefSE_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_coefSE_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, nu_max)
+calc_coefSE_binreg_weighted_eigenqr <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_coefSE_binreg_weighted_eigenqr`, X, y, weights, maxit, tol, qr_tol, eta_max)
 }
 
-fit_binreg_weighted_eigenqr <- function(X, y, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_fit_binreg_weighted_eigenqr`, X, y, weights, se, maxit, tol, qr_tol, nu_max)
+fit_binreg_weighted_eigenqr <- function(X, y, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_fit_binreg_weighted_eigenqr`, X, y, weights, se, maxit, tol, qr_tol, eta_max)
 }
 
-calc_ll_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_ll_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, nu_max)
+calc_ll_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, eta_max)
 }
 
-calc_coef_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_coef_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, nu_max)
+calc_coef_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_coef_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, eta_max)
 }
 
-calc_coefSE_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_coefSE_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, nu_max)
+calc_coefSE_binreg_weighted <- function(X, y, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_coefSE_binreg_weighted`, X, y, weights, maxit, tol, qr_tol, eta_max)
 }
 
-fit_binreg_weighted <- function(X, y, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_fit_binreg_weighted`, X, y, weights, se, maxit, tol, qr_tol, nu_max)
+fit_binreg_weighted <- function(X, y, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_fit_binreg_weighted`, X, y, weights, se, maxit, tol, qr_tol, eta_max)
 }
 
-calc_ll_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_ll_binreg`, X, y, maxit, tol, qr_tol, nu_max)
+calc_ll_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_ll_binreg`, X, y, maxit, tol, qr_tol, eta_max)
 }
 
-calc_coef_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_coef_binreg`, X, y, maxit, tol, qr_tol, nu_max)
+calc_coef_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_coef_binreg`, X, y, maxit, tol, qr_tol, eta_max)
 }
 
-calc_coefSE_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_calc_coefSE_binreg`, X, y, maxit, tol, qr_tol, nu_max)
+calc_coefSE_binreg <- function(X, y, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_calc_coefSE_binreg`, X, y, maxit, tol, qr_tol, eta_max)
 }
 
-fit_binreg <- function(X, y, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_fit_binreg`, X, y, se, maxit, tol, qr_tol, nu_max)
+fit_binreg <- function(X, y, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_fit_binreg`, X, y, se, maxit, tol, qr_tol, eta_max)
 }
 
 .calc_kinship <- function(prob_array) {
@@ -165,12 +165,12 @@ invert_founder_index <- function(cross_info) {
     .Call(`_qtl2_R_find_peaks_and_bayesint`, lod, pos, threshold, peakdrop, prob)
 }
 
-fit1_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, se = FALSE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_fit1_binary_addcovar`, genoprobs, pheno, addcovar, weights, se, maxit, tol, qr_tol, nu_max)
+fit1_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, se = FALSE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_fit1_binary_addcovar`, genoprobs, pheno, addcovar, weights, se, maxit, tol, qr_tol, eta_max)
 }
 
-fit1_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_fit1_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, se, maxit, tol, qr_tol, nu_max)
+fit1_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, se = TRUE, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_fit1_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, se, maxit, tol, qr_tol, eta_max)
 }
 
 fit1_hk_addcovar <- function(genoprobs, pheno, addcovar, weights, se = FALSE, tol = 1e-12) {
@@ -461,12 +461,12 @@ permute_ivector_stratified <- function(n_perm, x, strata, n_strata = -1L) {
     .Call(`_qtl2_reduce_markers`, pos, min_dist, weights)
 }
 
-scan_binary_onechr <- function(genoprobs, pheno, addcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_scan_binary_onechr`, genoprobs, pheno, addcovar, maxit, tol, qr_tol, nu_max)
+scan_binary_onechr <- function(genoprobs, pheno, addcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_scan_binary_onechr`, genoprobs, pheno, addcovar, maxit, tol, qr_tol, eta_max)
 }
 
-scan_binary_onechr_weighted <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_scan_binary_onechr_weighted`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max)
+scan_binary_onechr_weighted <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_scan_binary_onechr_weighted`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, eta_max)
 }
 
 scan_binary_onechr_intcovar_highmem <- function(genoprobs, pheno, addcovar, intcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {
@@ -477,12 +477,12 @@ scan_binary_onechr_intcovar_weighted_highmem <- function(genoprobs, pheno, addco
     .Call(`_qtl2_scan_binary_onechr_intcovar_weighted_highmem`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol)
 }
 
-scan_binary_onechr_intcovar_lowmem <- function(genoprobs, pheno, addcovar, intcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_scan_binary_onechr_intcovar_lowmem`, genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, nu_max)
+scan_binary_onechr_intcovar_lowmem <- function(genoprobs, pheno, addcovar, intcovar, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_scan_binary_onechr_intcovar_lowmem`, genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, eta_max)
 }
 
-scan_binary_onechr_intcovar_weighted_lowmem <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_scan_binary_onechr_intcovar_weighted_lowmem`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max)
+scan_binary_onechr_intcovar_weighted_lowmem <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_scan_binary_onechr_intcovar_weighted_lowmem`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, eta_max)
 }
 
 scan_hk_onechr_nocovar <- function(genoprobs, pheno, tol = 1e-12) {
@@ -529,20 +529,20 @@ scanblup <- function(genoprobs, pheno, addcovar, se, reml, tol = 1e-12) {
     .Call(`_qtl2_scanblup`, genoprobs, pheno, addcovar, se, reml, tol)
 }
 
-scancoef_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_scancoef_binary_addcovar`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max)
+scancoef_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_scancoef_binary_addcovar`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, eta_max)
 }
 
-scancoef_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_scancoef_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max)
+scancoef_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_scancoef_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, eta_max)
 }
 
-scancoefSE_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_scancoefSE_binary_addcovar`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max)
+scancoefSE_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_scancoefSE_binary_addcovar`, genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, eta_max)
 }
 
-scancoefSE_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, nu_max = 30.0) {
-    .Call(`_qtl2_scancoefSE_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max)
+scancoefSE_binary_intcovar <- function(genoprobs, pheno, addcovar, intcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12, eta_max = 30.0) {
+    .Call(`_qtl2_scancoefSE_binary_intcovar`, genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, eta_max)
 }
 
 scancoef_hk_addcovar <- function(genoprobs, pheno, addcovar, weights, tol = 1e-12) {

--- a/R/fit1.R
+++ b/R/fit1.R
@@ -68,7 +68,7 @@
 #' `1e-12`. `maxit` is the maximum number of iteractions for
 #' converence of the iterative algorithm used when `model=binary`.
 #' `bintol` is used as a tolerance for converence for the iterative
-#' algorithm used when `model=binary`. `nu_max` is the maximum value
+#' algorithm used when `model=binary`. `eta_max` is the maximum value
 #' for the "linear predictor" in the case `model="binary"` (a bit of a
 #' technicality to avoid fitted values exactly at 0 or 1).
 #'
@@ -138,12 +138,12 @@ fit1 <-
     if(model=="binary") {
         bintol <- grab_dots(dotargs, "bintol", sqrt(tol)) # for model="binary"
         if(!is_pos_number(bintol)) stop("bintol should be a single positive number")
-        nu_max <- grab_dots(dotargs, "nu_max", log(1-tol)-log(tol)) # for model="binary"
-        if(!is_pos_number(nu_max)) stop("nu_max should be a single positive number")
+        eta_max <- grab_dots(dotargs, "eta_max", log(1-tol)-log(tol)) # for model="binary"
+        if(!is_pos_number(eta_max)) stop("eta_max should be a single positive number")
         maxit <- grab_dots(dotargs, "maxit", 100) # for model="binary"
         if(!is_nonneg_number(maxit)) stop("maxit should be a single non-negative integer")
 
-        check_extra_dots(dotargs, c("tol", "bintol", "nu_max", "maxit"))
+        check_extra_dots(dotargs, c("tol", "bintol", "eta_max", "maxit"))
     }
     else { # not binary trait
         check_extra_dots(dotargs, "tol")
@@ -272,21 +272,21 @@ fit1 <-
     else { # binary phenotype
         # null fit
         if(is.null(weights)) { # no weights
-            fit0 <- fit_binreg(X0, pheno, FALSE, maxit, bintol, tol, nu_max)
+            fit0 <- fit_binreg(X0, pheno, FALSE, maxit, bintol, tol, eta_max)
             weights <- numeric(0)
         }
         else {
-            fit0 <- fit_binreg_weighted(X0, pheno, weights, FALSE, maxit, bintol, tol, nu_max)
+            fit0 <- fit_binreg_weighted(X0, pheno, weights, FALSE, maxit, bintol, tol, eta_max)
         }
 
         if(is.null(intcovar)) { # just addcovar
             if(is.null(addcovar)) addcovar <- matrix(nrow=length(ind2keep), ncol=0)
             fitA <- fit1_binary_addcovar(genoprobs, pheno, addcovar, weights, se=se,
-                                         maxit, bintol, tol, nu_max)
+                                         maxit, bintol, tol, eta_max)
         }
         else {                  # intcovar
             fitA <- fit1_binary_intcovar(genoprobs, pheno, addcovar, intcovar,
-                                         weights, se=se, maxit, bintol, tol, nu_max)
+                                         weights, se=se, maxit, bintol, tol, eta_max)
         }
 
         lod <- fitA$log10lik - fit0$log10lik

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -75,7 +75,7 @@
 #' number of iteractions for converence of the iterative algorithm
 #' used when `model=binary`. `bintol` is used as a tolerance for
 #' converence for the iterative algorithm used when `model=binary`.
-#' `nu_max` is the maximum value for the "linear predictor" in the
+#' `eta_max` is the maximum value for the "linear predictor" in the
 #' case `model="binary"` (a bit of a technicality to avoid fitted
 #' values exactly at 0 or 1).
 #'
@@ -158,11 +158,11 @@ scan1 <-
     if(model=="binary") {
         bintol <- grab_dots(dotargs, "bintol", sqrt(tol)) # for model="binary"
         if(!is_pos_number(bintol)) stop("bintol should be a single positive number")
-        nu_max <- grab_dots(dotargs, "nu_max", log(1-tol)-log(tol)) # for model="binary"
-        if(!is_pos_number(nu_max)) stop("nu_max should be a single positive number")
+        eta_max <- grab_dots(dotargs, "eta_max", log(1-tol)-log(tol)) # for model="binary"
+        if(!is_pos_number(eta_max)) stop("eta_max should be a single positive number")
         maxit <- grab_dots(dotargs, "maxit", 100) # for model="binary"
         if(!is_nonneg_number(maxit)) stop("maxit should be a single non-negative integer")
-        check_extra_dots(dotargs, c("tol", "intcovar_method", "quiet", "max_batch", "maxit", "bintol", "nu_max"))
+        check_extra_dots(dotargs, c("tol", "intcovar_method", "quiet", "max_batch", "maxit", "bintol", "eta_max"))
     }
     else {
         check_extra_dots(dotargs, c("tol", "intcovar_method", "quiet", "max_batch"))
@@ -289,11 +289,11 @@ scan1 <-
         }
         else { # binary traits
             # FIX_ME: calculating null LOD multiple times :(
-            nulllod <- null_binary_clean(ph, ac0, wts, add_intercept=TRUE, maxit, bintol, tol, nu_max)
+            nulllod <- null_binary_clean(ph, ac0, wts, add_intercept=TRUE, maxit, bintol, tol, eta_max)
 
             # scan1 function taking clean data (with no missing values)
             lod <- scan1_binary_clean(pr, ph, ac, ic, wts, add_intercept=TRUE,
-                                      maxit, bintol, tol, intcovar_method, nu_max)
+                                      maxit, bintol, tol, intcovar_method, eta_max)
 
             # calculate LOD score
             lod <- lod - nulllod

--- a/R/scan1_binary.R
+++ b/R/scan1_binary.R
@@ -6,7 +6,7 @@
 scan1_binary_clean <-
     function(genoprobs, pheno, addcovar, intcovar,
              weights, add_intercept=TRUE, maxit, tol, qr_tol,
-             intcovar_method, nu_max=30)
+             intcovar_method, eta_max=30)
 {
     n <- nrow(pheno)
     if(add_intercept)
@@ -15,9 +15,9 @@ scan1_binary_clean <-
     if(is.null(intcovar)) { # no interactive covariates
 
         if(is.null(weights)) { # no weights
-            return( scan_binary_onechr(genoprobs, pheno, addcovar, maxit, tol, qr_tol, nu_max) )
+            return( scan_binary_onechr(genoprobs, pheno, addcovar, maxit, tol, qr_tol, eta_max) )
         } else { # weights included
-            return( scan_binary_onechr_weighted(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max) )
+            return( scan_binary_onechr_weighted(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, eta_max) )
         }
 
     } else { # interactive covariates
@@ -30,9 +30,9 @@ scan1_binary_clean <-
                        scan_binary_onechr_intcovar_weighted_lowmem)
 
         if(is.null(weights)) { # no weights
-            return( scanf[[1]](genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, nu_max) )
+            return( scanf[[1]](genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, eta_max) )
         } else { # weights included
-            return( scanf[[2]](genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max) )
+            return( scanf[[2]](genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, eta_max) )
         }
 
     }
@@ -40,17 +40,17 @@ scan1_binary_clean <-
 
 # calculate null log likelihood, with nicely aligned data with no missing values
 null_binary_clean <-
-    function(pheno, addcovar, weights, add_intercept=TRUE, maxit, tol, qr_tol, nu_max=30)
+    function(pheno, addcovar, weights, add_intercept=TRUE, maxit, tol, qr_tol, eta_max=30)
 {
     n <- nrow(pheno)
     if(add_intercept)
         addcovar <- cbind(rep(1,n), addcovar) # add intercept
 
     if(is.null(weights) || length(weights)==0) { # no weights
-        result <- apply(pheno, 2, function(phe) calc_ll_binreg(addcovar, phe, maxit, tol, qr_tol, nu_max))
+        result <- apply(pheno, 2, function(phe) calc_ll_binreg(addcovar, phe, maxit, tol, qr_tol, eta_max))
     } else { # weights included
         result <- apply(pheno, 2, function(phe) calc_ll_binreg_weighted(addcovar, phe, weights, maxit, tol,
-                                                                        qr_tol, nu_max))
+                                                                        qr_tol, eta_max))
     }
 
     as.numeric(result)

--- a/R/scan1coef.R
+++ b/R/scan1coef.R
@@ -75,7 +75,7 @@
 #' `1e-12`. `maxit` is the maximum number of iteractions for
 #' converence of the iterative algorithm used when `model=binary`.
 #' `bintol` is used as a tolerance for converence for the iterative
-#' algorithm used when `model=binary`. `nu_max` is the maximum value
+#' algorithm used when `model=binary`. `eta_max` is the maximum value
 #' for the "linear predictor" in the case `model="binary"` (a bit of a
 #' technicality to avoid fitted values exactly at 0 or 1).
 #'
@@ -137,12 +137,12 @@ scan1coef <-
     if(model=="binary") {
         bintol <- grab_dots(dotargs, "bintol", sqrt(tol)) # for model="binary"
         if(!is_pos_number(bintol)) stop("bintol should be a single positive number")
-        nu_max <- grab_dots(dotargs, "nu_max", log(1-tol)-log(tol)) # for model="binary"
-        if(!is_pos_number(nu_max)) stop("nu_max should be a single positive number")
+        eta_max <- grab_dots(dotargs, "eta_max", log(1-tol)-log(tol)) # for model="binary"
+        if(!is_pos_number(eta_max)) stop("eta_max should be a single positive number")
         maxit <- grab_dots(dotargs, "maxit", 100) # for model="binary"
         if(!is_nonneg_number(maxit)) stop("maxit should be a single non-negative integer")
 
-        check_extra_dots(dotargs, c("tol", "bintol", "nu_max", "maxit"))
+        check_extra_dots(dotargs, c("tol", "bintol", "eta_max", "maxit"))
     }
     else { # not binary trait
         check_extra_dots(dotargs, "tol")
@@ -246,7 +246,7 @@ scan1coef <-
             if(model=="normal")
                 result <- scancoefSE_hk_addcovar(genoprobs, pheno, addcovar, weights, tol)
             else # binary trait
-                result <- scancoefSE_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, bintol, tol, nu_max)
+                result <- scancoefSE_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, bintol, tol, eta_max)
         }
         else {                  # intcovar
             if(model=="normal")
@@ -254,7 +254,7 @@ scan1coef <-
                                                  weights, tol)
             else
                 result <- scancoefSE_binary_intcovar(genoprobs, pheno, addcovar, intcovar,
-                                                 weights, maxit, bintol, tol, nu_max)
+                                                 weights, maxit, bintol, tol, eta_max)
         }
 
         SE <- t(result$SE) # transpose to positions x coefficients
@@ -266,7 +266,7 @@ scan1coef <-
             if(model=="normal")
                 result <- scancoef_hk_addcovar(genoprobs, pheno, addcovar, weights, tol)
             else
-                result <- scancoef_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, bintol, tol, nu_max)
+                result <- scancoef_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, bintol, tol, eta_max)
         }
         else {                  # intcovar
             if(model=="normal")
@@ -274,7 +274,7 @@ scan1coef <-
                                                weights, tol)
             else
                 result <- scancoef_binary_intcovar(genoprobs, pheno, addcovar, intcovar,
-                                                   weights, maxit, bintol, tol, nu_max)
+                                                   weights, maxit, bintol, tol, eta_max)
         }
         SE <- NULL
     }

--- a/R/scan1perm.R
+++ b/R/scan1perm.R
@@ -69,7 +69,7 @@
 #' `1e-12`. `maxit` is the maximum number of iteractions for
 #' converence of the iterative algorithm used when `model=binary`.
 #' `bintol` is used as a tolerance for converence for the iterative
-#' algorithm used when `model=binary`. `nu_max` is the maximum value
+#' algorithm used when `model=binary`. `eta_max` is the maximum value
 #' for the "linear predictor" in the case `model="binary"` (a bit of a
 #' technicality to avoid fitted values exactly at 0 or 1).
 #'
@@ -409,12 +409,12 @@ scan1perm_covar <-
     if(model=="binary") {
         bintol <- grab_dots(dotargs, "bintol", sqrt(tol))
         if(!is_pos_number(bintol)) stop("bintol should be a single positive number")
-        nu_max <- grab_dots(dotargs, "nu_max", log(1-tol)-log(tol)) # for model="binary"
-        if(!is_pos_number(nu_max)) stop("nu_max should be a single positive number")
+        eta_max <- grab_dots(dotargs, "eta_max", log(1-tol)-log(tol)) # for model="binary"
+        if(!is_pos_number(eta_max)) stop("eta_max should be a single positive number")
         maxit <- grab_dots(dotargs, "maxit", 100)
         if(!is_nonneg_number(maxit)) stop("maxit should be a single non-negative integer")
         check_extra_dots(dotargs, c("tol", "intcovar_method", "quiet", "max_batch",
-                                    "maxit", "bintol", "nu_max"))
+                                    "maxit", "bintol", "eta_max"))
     }
     else {
         check_extra_dots(dotargs, c("tol", "intcovar_method", "quiet", "max_batch"))
@@ -504,11 +504,11 @@ scan1perm_covar <-
         }
         else { # binary model
             # FIX_ME: calculating null LOD multiple times :(
-            nulllod <- null_binary_clean(ph, ac0, wts, add_intercept=TRUE, maxit, bintol, tol, nu_max)
+            nulllod <- null_binary_clean(ph, ac0, wts, add_intercept=TRUE, maxit, bintol, tol, eta_max)
 
             # scan1 function taking clean data (with no missing values)
             lod <- scan1_binary_clean(pr, ph, ac, ic, wts, add_intercept=TRUE,
-                                      maxit, bintol, tol, intcovar_method, nu_max)
+                                      maxit, bintol, tol, intcovar_method, eta_max)
 
             # calculate LOD score
             lod <- lod - nulllod

--- a/man/fit1.Rd
+++ b/man/fit1.Rd
@@ -92,7 +92,7 @@ linearly dependent on others and should be omitted); default
 \code{1e-12}. \code{maxit} is the maximum number of iteractions for
 converence of the iterative algorithm used when \code{model=binary}.
 \code{bintol} is used as a tolerance for converence for the iterative
-algorithm used when \code{model=binary}. \code{nu_max} is the maximum value
+algorithm used when \code{model=binary}. \code{eta_max} is the maximum value
 for the "linear predictor" in the case \code{model="binary"} (a bit of a
 technicality to avoid fitted values exactly at 0 or 1).
 }

--- a/man/scan1.Rd
+++ b/man/scan1.Rd
@@ -96,7 +96,7 @@ to run together; default is unlimited. \code{maxit} is the maximum
 number of iteractions for converence of the iterative algorithm
 used when \code{model=binary}. \code{bintol} is used as a tolerance for
 converence for the iterative algorithm used when \code{model=binary}.
-\code{nu_max} is the maximum value for the "linear predictor" in the
+\code{eta_max} is the maximum value for the "linear predictor" in the
 case \code{model="binary"} (a bit of a technicality to avoid fitted
 values exactly at 0 or 1).
 

--- a/man/scan1coef.Rd
+++ b/man/scan1coef.Rd
@@ -100,7 +100,7 @@ linearly dependent on others and should be omitted); default
 \code{1e-12}. \code{maxit} is the maximum number of iteractions for
 converence of the iterative algorithm used when \code{model=binary}.
 \code{bintol} is used as a tolerance for converence for the iterative
-algorithm used when \code{model=binary}. \code{nu_max} is the maximum value
+algorithm used when \code{model=binary}. \code{eta_max} is the maximum value
 for the "linear predictor" in the case \code{model="binary"} (a bit of a
 technicality to avoid fitted values exactly at 0 or 1).
 }

--- a/man/scan1perm.Rd
+++ b/man/scan1perm.Rd
@@ -93,7 +93,7 @@ linearly dependent on others and should be omitted); default
 \code{1e-12}. \code{maxit} is the maximum number of iteractions for
 converence of the iterative algorithm used when \code{model=binary}.
 \code{bintol} is used as a tolerance for converence for the iterative
-algorithm used when \code{model=binary}. \code{nu_max} is the maximum value
+algorithm used when \code{model=binary}. \code{eta_max} is the maximum value
 for the "linear predictor" in the case \code{model="binary"} (a bit of a
 technicality to avoid fitted values exactly at 0 or 1).
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -32,8 +32,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // calc_ll_binreg_eigenchol
-double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_ll_binreg_eigenchol(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP nu_maxSEXP) {
+double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_eigenchol(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -41,14 +41,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const NumericVector& >::type y(ySEXP);
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_eigenchol(X, y, maxit, tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_eigenchol(X, y, maxit, tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg_eigenqr
-double calc_ll_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_ll_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+double calc_ll_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -57,14 +57,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_eigenqr(X, y, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coef_binreg_eigenqr
-NumericVector calc_coef_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_coef_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericVector calc_coef_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_coef_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -73,14 +73,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_eigenqr(X, y, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coefSE_binreg_eigenqr
-List calc_coefSE_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_coefSE_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List calc_coefSE_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_coefSE_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -89,14 +89,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_eigenqr(X, y, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit_binreg_eigenqr
-List fit_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_fit_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List fit_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y, const bool se, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_fit_binreg_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -106,14 +106,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit_binreg_eigenqr(X, y, se, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit_binreg_eigenqr(X, y, se, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg_weighted_eigenchol
-double calc_ll_binreg_weighted_eigenchol(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_ll_binreg_weighted_eigenchol(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP nu_maxSEXP) {
+double calc_ll_binreg_weighted_eigenchol(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_weighted_eigenchol(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -122,14 +122,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted_eigenchol(X, y, weights, maxit, tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted_eigenchol(X, y, weights, maxit, tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg_weighted_eigenqr
-double calc_ll_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_ll_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+double calc_ll_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -139,14 +139,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coef_binreg_weighted_eigenqr
-NumericVector calc_coef_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_coef_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericVector calc_coef_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_coef_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -156,14 +156,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coefSE_binreg_weighted_eigenqr
-List calc_coefSE_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_coefSE_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List calc_coefSE_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_coefSE_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -173,14 +173,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit_binreg_weighted_eigenqr
-List fit_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_fit_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List fit_binreg_weighted_eigenqr(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_fit_binreg_weighted_eigenqr(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -191,14 +191,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit_binreg_weighted_eigenqr(X, y, weights, se, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit_binreg_weighted_eigenqr(X, y, weights, se, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg_weighted
-double calc_ll_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_ll_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+double calc_ll_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_ll_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -208,14 +208,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted(X, y, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg_weighted(X, y, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coef_binreg_weighted
-NumericVector calc_coef_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_coef_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericVector calc_coef_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_coef_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -225,14 +225,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_weighted(X, y, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg_weighted(X, y, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coefSE_binreg_weighted
-List calc_coefSE_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_coefSE_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List calc_coefSE_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_coefSE_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -242,14 +242,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_weighted(X, y, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg_weighted(X, y, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit_binreg_weighted
-List fit_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_fit_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List fit_binreg_weighted(const NumericMatrix& X, const NumericVector& y, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_fit_binreg_weighted(SEXP XSEXP, SEXP ySEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -260,14 +260,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit_binreg_weighted(X, y, weights, se, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit_binreg_weighted(X, y, weights, se, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_ll_binreg
-double calc_ll_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_ll_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+double calc_ll_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_ll_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -276,14 +276,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg(X, y, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_ll_binreg(X, y, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coef_binreg
-NumericVector calc_coef_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_coef_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericVector calc_coef_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_coef_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -292,14 +292,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg(X, y, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coef_binreg(X, y, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // calc_coefSE_binreg
-List calc_coefSE_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_calc_coefSE_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List calc_coefSE_binreg(const NumericMatrix& X, const NumericVector& y, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_calc_coefSE_binreg(SEXP XSEXP, SEXP ySEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -308,14 +308,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg(X, y, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(calc_coefSE_binreg(X, y, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit_binreg
-List fit_binreg(const NumericMatrix& X, const NumericVector& y, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_fit_binreg(SEXP XSEXP, SEXP ySEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List fit_binreg(const NumericMatrix& X, const NumericVector& y, const bool se, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_fit_binreg(SEXP XSEXP, SEXP ySEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -325,8 +325,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit_binreg(X, y, se, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit_binreg(X, y, se, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -597,8 +597,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // fit1_binary_addcovar
-List fit1_binary_addcovar(const NumericMatrix& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_fit1_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List fit1_binary_addcovar(const NumericMatrix& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_fit1_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -610,14 +610,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit1_binary_addcovar(genoprobs, pheno, addcovar, weights, se, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit1_binary_addcovar(genoprobs, pheno, addcovar, weights, se, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // fit1_binary_intcovar
-List fit1_binary_intcovar(const NumericMatrix& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_fit1_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List fit1_binary_intcovar(const NumericMatrix& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const bool se, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_fit1_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP seSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -630,8 +630,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(fit1_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, se, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(fit1_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, se, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1638,8 +1638,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // scan_binary_onechr
-NumericMatrix scan_binary_onechr(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_scan_binary_onechr(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericMatrix scan_binary_onechr(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_scan_binary_onechr(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1649,14 +1649,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr(genoprobs, pheno, addcovar, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr(genoprobs, pheno, addcovar, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scan_binary_onechr_weighted
-NumericMatrix scan_binary_onechr_weighted(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_scan_binary_onechr_weighted(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericMatrix scan_binary_onechr_weighted(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_scan_binary_onechr_weighted(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1667,8 +1667,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_weighted(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_weighted(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1708,8 +1708,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // scan_binary_onechr_intcovar_lowmem
-NumericMatrix scan_binary_onechr_intcovar_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_scan_binary_onechr_intcovar_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericMatrix scan_binary_onechr_intcovar_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_scan_binary_onechr_intcovar_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1720,14 +1720,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_intcovar_lowmem(genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_intcovar_lowmem(genoprobs, pheno, addcovar, intcovar, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scan_binary_onechr_intcovar_weighted_lowmem
-NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_scan_binary_onechr_intcovar_weighted_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_scan_binary_onechr_intcovar_weighted_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1739,8 +1739,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_intcovar_weighted_lowmem(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scan_binary_onechr_intcovar_weighted_lowmem(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1915,8 +1915,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // scancoef_binary_addcovar
-NumericMatrix scancoef_binary_addcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_scancoef_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericMatrix scancoef_binary_addcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_scancoef_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1927,14 +1927,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(scancoef_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scancoef_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scancoef_binary_intcovar
-NumericMatrix scancoef_binary_intcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_scancoef_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+NumericMatrix scancoef_binary_intcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_scancoef_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1946,14 +1946,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(scancoef_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scancoef_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scancoefSE_binary_addcovar
-List scancoefSE_binary_addcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_scancoefSE_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List scancoefSE_binary_addcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_scancoefSE_binary_addcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1964,14 +1964,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(scancoefSE_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scancoefSE_binary_addcovar(genoprobs, pheno, addcovar, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }
 // scancoefSE_binary_intcovar
-List scancoefSE_binary_intcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double nu_max);
-RcppExport SEXP _qtl2_scancoefSE_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP nu_maxSEXP) {
+List scancoefSE_binary_intcovar(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const int maxit, const double tol, const double qr_tol, const double eta_max);
+RcppExport SEXP _qtl2_scancoefSE_binary_intcovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP maxitSEXP, SEXP tolSEXP, SEXP qr_tolSEXP, SEXP eta_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1983,8 +1983,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type maxit(maxitSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< const double >::type qr_tol(qr_tolSEXP);
-    Rcpp::traits::input_parameter< const double >::type nu_max(nu_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(scancoefSE_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, nu_max));
+    Rcpp::traits::input_parameter< const double >::type eta_max(eta_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(scancoefSE_binary_intcovar(genoprobs, pheno, addcovar, intcovar, weights, maxit, tol, qr_tol, eta_max));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/binreg.cpp
+++ b/src/binreg.cpp
@@ -14,9 +14,9 @@ using namespace Eigen;
 // [[Rcpp::export]]
 double calc_ll_binreg(const NumericMatrix& X, const NumericVector& y,
                       const int maxit=100, const double tol=1e-6,
-                      const double qr_tol=1e-12, const double nu_max=30.0)
+                      const double qr_tol=1e-12, const double eta_max=30.0)
 {
-    return calc_ll_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max);
+    return calc_ll_binreg_eigenqr(X, y, maxit, tol, qr_tol, eta_max);
 }
 
 // logistic regression
@@ -24,9 +24,9 @@ double calc_ll_binreg(const NumericMatrix& X, const NumericVector& y,
 // [[Rcpp::export]]
 NumericVector calc_coef_binreg(const NumericMatrix& X, const NumericVector& y,
                                const int maxit=100, const double tol=1e-6,
-                               const double qr_tol=1e-12, const double nu_max=30.0)
+                               const double qr_tol=1e-12, const double eta_max=30.0)
 {
-    return calc_coef_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max);
+    return calc_coef_binreg_eigenqr(X, y, maxit, tol, qr_tol, eta_max);
 }
 
 // logistic regression
@@ -34,9 +34,9 @@ NumericVector calc_coef_binreg(const NumericMatrix& X, const NumericVector& y,
 // [[Rcpp::export]]
 List calc_coefSE_binreg(const NumericMatrix& X, const NumericVector& y,
                         const int maxit=100, const double tol=1e-6,
-                        const double qr_tol=1e-12, const double nu_max=30.0)
+                        const double qr_tol=1e-12, const double eta_max=30.0)
 {
-    return calc_coefSE_binreg_eigenqr(X, y, maxit, tol, qr_tol, nu_max);
+    return calc_coefSE_binreg_eigenqr(X, y, maxit, tol, qr_tol, eta_max);
 }
 
 // logistic regression
@@ -45,7 +45,7 @@ List calc_coefSE_binreg(const NumericMatrix& X, const NumericVector& y,
 List fit_binreg(const NumericMatrix& X, const NumericVector& y,
                 const bool se=true, // whether to include SEs
                 const int maxit=100, const double tol=1e-6,
-                const double qr_tol=1e-12, const double nu_max=30.0)
+                const double qr_tol=1e-12, const double eta_max=30.0)
 {
-    return fit_binreg_eigenqr(X, y, se, maxit, tol, qr_tol, nu_max);
+    return fit_binreg_eigenqr(X, y, se, maxit, tol, qr_tol, eta_max);
 }

--- a/src/binreg.h
+++ b/src/binreg.h
@@ -11,7 +11,7 @@ double calc_ll_binreg(const Rcpp::NumericMatrix& X,
                       const int maxit,
                       const double tol,
                       const double qr_tol,
-                      const double nu_max);
+                      const double eta_max);
 
 // logistic regression
 // return just the coefficients
@@ -20,7 +20,7 @@ Rcpp::NumericVector calc_coef_binreg(const Rcpp::NumericMatrix& X,
                                      const int maxit,
                                      const double tol,
                                      const double qr_tol,
-                                     const double nu_max);
+                                     const double eta_max);
 
 // logistic regression
 // return the coefficients and SEs
@@ -29,7 +29,7 @@ Rcpp::List calc_coefSE_binreg(const Rcpp::NumericMatrix& X,
                               const int maxit,
                               const double tol,
                               const double qr_tol,
-                              const double nu_max);
+                              const double eta_max);
 
 // logistic regression
 // return (llik, individual contributions to llik, fitted probabilities, coef, SE
@@ -39,7 +39,7 @@ Rcpp::List fit_binreg(const Rcpp::NumericMatrix& X,
                       const int maxit,
                       const double tol,
                       const double qr_tol,
-                      const double nu_max);
+                      const double eta_max);
 
 
 #endif // BINREG_H

--- a/src/binreg_eigen.cpp
+++ b/src/binreg_eigen.cpp
@@ -17,12 +17,12 @@ using namespace Eigen;
 //
 // maxit = maximum number of iterations
 // tol = tolerance for convergence
-// nu_max = maximum value for linear predictor
+// eta_max = maximum value for linear predictor
 //
 // [[Rcpp::export]]
 double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y,
                                 const int maxit=100, const double tol=1e-6,
-                                const double nu_max=30.0)
+                                const double eta_max=30.0)
 {
     const int n_ind = y.size();
     #ifndef RQTL2_NODEBUG
@@ -31,13 +31,13 @@ double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y,
     #endif
 
     double curllik = 0.0;
-    NumericVector pi(n_ind), wt(n_ind), nu(n_ind), z(n_ind);
+    NumericVector pi(n_ind), wt(n_ind), eta(n_ind), z(n_ind);
 
     for(int ind=0; ind<n_ind; ind++) {
         pi[ind] = (y[ind] + 0.5)/2;
         wt[ind] = sqrt(pi[ind] * (1-pi[ind]));
-        nu[ind] = log(pi[ind]) - log(1-pi[ind]);
-        z[ind] = nu[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
+        eta[ind] = log(pi[ind]) - log(1-pi[ind]);
+        z[ind] = eta[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
         curllik += y[ind] * log10(pi[ind]) + (1.0-y[ind])*log10(1.0-pi[ind]);
     }
 
@@ -50,20 +50,20 @@ double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y,
         Rcpp::checkUserInterrupt();  // check for ^C from user
 
         // fitted values using weighted XX; will need to divide by previous weights
-        nu = calc_fitted_linreg_eigenchol(XX, z);
+        eta = calc_fitted_linreg_eigenchol(XX, z);
 
         llik = 0.0;
         for(int ind=0; ind<n_ind; ind++) {
-            nu[ind] /= wt[ind]; // need to divide by previous weights
+            eta[ind] /= wt[ind]; // need to divide by previous weights
 
-            // don't let nu get too large or too small
-            if(nu[ind] < -nu_max) nu[ind] = -nu_max;
-            else if(nu[ind] > nu_max) nu[ind] = nu_max;
+            // don't let eta get too large or too small
+            if(eta[ind] < -eta_max) eta[ind] = -eta_max;
+            else if(eta[ind] > eta_max) eta[ind] = eta_max;
 
-            pi[ind] = exp(nu[ind])/(1.0 + exp(nu[ind]));
+            pi[ind] = exp(eta[ind])/(1.0 + exp(eta[ind]));
 
             wt[ind] = sqrt(pi[ind] * (1.0 - pi[ind]));
-            z[ind] = nu[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
+            z[ind] = eta[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
             llik += y[ind] * log10(pi[ind]) + (1.0-y[ind])*log10(1.0-pi[ind]);
         }
 
@@ -89,12 +89,12 @@ double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y,
 // maxit = maximum number of iterations
 // tol = tolerance for convergence
 // qr_tol = tolerance for QR decomposition
-// nu_max = maximum value for linear predictor
+// eta_max = maximum value for linear predictor
 //
 // [[Rcpp::export]]
 double calc_ll_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
                               const int maxit=100, const double tol=1e-6,
-                              const double qr_tol=1e-12, const double nu_max=30.0)
+                              const double qr_tol=1e-12, const double eta_max=30.0)
 {
     const int n_ind = y.size();
     #ifndef RQTL2_NODEBUG
@@ -103,13 +103,13 @@ double calc_ll_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
     #endif
 
     double curllik = 0.0;
-    NumericVector pi(n_ind), wt(n_ind), nu(n_ind), z(n_ind);
+    NumericVector pi(n_ind), wt(n_ind), eta(n_ind), z(n_ind);
 
     for(int ind=0; ind<n_ind; ind++) {
         pi[ind] = (y[ind] + 0.5)/2;
         wt[ind] = sqrt(pi[ind] * (1-pi[ind]));
-        nu[ind] = log(pi[ind]) - log(1-pi[ind]);
-        z[ind] = nu[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
+        eta[ind] = log(pi[ind]) - log(1-pi[ind]);
+        z[ind] = eta[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
         curllik += y[ind] * log10(pi[ind]) + (1.0-y[ind])*log10(1.0-pi[ind]);
     }
 
@@ -122,20 +122,20 @@ double calc_ll_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
         Rcpp::checkUserInterrupt();  // check for ^C from user
 
         // fitted values using weighted XX; will need to divide by previous weights
-        nu = calc_fitted_linreg_eigenqr(XX, z, qr_tol);
+        eta = calc_fitted_linreg_eigenqr(XX, z, qr_tol);
 
         llik = 0.0;
         for(int ind=0; ind<n_ind; ind++) {
-            nu[ind] /= wt[ind]; // need to divide by previous weights
+            eta[ind] /= wt[ind]; // need to divide by previous weights
 
-            // don't let nu get too large or too small
-            if(nu[ind] < -nu_max) nu[ind] = -nu_max;
-            else if(nu[ind] > nu_max) nu[ind] = nu_max;
+            // don't let eta get too large or too small
+            if(eta[ind] < -eta_max) eta[ind] = -eta_max;
+            else if(eta[ind] > eta_max) eta[ind] = eta_max;
 
-            pi[ind] = exp(nu[ind])/(1.0 + exp(nu[ind]));
+            pi[ind] = exp(eta[ind])/(1.0 + exp(eta[ind]));
 
             wt[ind] = sqrt(pi[ind] * (1.0 - pi[ind]));
-            z[ind] = nu[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
+            z[ind] = eta[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
             llik += y[ind] * log10(pi[ind]) + (1.0-y[ind])*log10(1.0-pi[ind]);
         }
 
@@ -162,9 +162,9 @@ NumericVector calc_coef_binreg_eigenqr(const NumericMatrix& X,
                                        const int maxit=100,       // max iterations
                                        const double tol=1e-6,     // tolerance for convergence
                                        const double qr_tol=1e-12, // tolerance for QR decomp
-                                       const double nu_max=30.0)  // max value for linear predictor
+                                       const double eta_max=30.0)  // max value for linear predictor
 {
-    List fit = fit_binreg_eigenqr(X, y, false, maxit, tol, qr_tol, nu_max);
+    List fit = fit_binreg_eigenqr(X, y, false, maxit, tol, qr_tol, eta_max);
 
     NumericVector coef = fit[2];
 
@@ -179,9 +179,9 @@ List calc_coefSE_binreg_eigenqr(const NumericMatrix& X,
                                 const int maxit=100,       // max iterations
                                 const double tol=1e-6,     // tolerance for convergence
                                 const double qr_tol=1e-12, // tolerance for QR decomp
-                                const double nu_max=30.0)  // max value for linear predictor
+                                const double eta_max=30.0)  // max value for linear predictor
 {
-    List fit = fit_binreg_eigenqr(X, y, true, maxit, tol, qr_tol, nu_max);
+    List fit = fit_binreg_eigenqr(X, y, true, maxit, tol, qr_tol, eta_max);
 
     NumericVector coef = fit[2];
     NumericVector SE = fit[3];
@@ -199,7 +199,7 @@ List fit_binreg_eigenqr(const NumericMatrix& X,
                         const int maxit=100,       // max iterations
                         const double tol=1e-6,     // tolerance for convergence
                         const double qr_tol=1e-12, // tolerance for QR decomp
-                        const double nu_max=30.0)  // max value for linear predictor
+                        const double eta_max=30.0)  // max value for linear predictor
 {
     const int n_ind = y.size();
     #ifndef RQTL2_NODEBUG
@@ -208,13 +208,13 @@ List fit_binreg_eigenqr(const NumericMatrix& X,
     #endif
 
     double curllik = 0.0;
-    NumericVector pi(n_ind), wt(n_ind), nu(n_ind), z(n_ind);
+    NumericVector pi(n_ind), wt(n_ind), eta(n_ind), z(n_ind);
 
     for(int ind=0; ind<n_ind; ind++) {
         pi[ind] = (y[ind] + 0.5)/2.0;
         wt[ind] = sqrt(pi[ind] * (1.0-pi[ind]));
-        nu[ind] = log(pi[ind]) - log(1.0-pi[ind]);
-        z[ind] = nu[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
+        eta[ind] = log(pi[ind]) - log(1.0-pi[ind]);
+        z[ind] = eta[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
 
         curllik += y[ind] * log10(pi[ind]) + (1.0-y[ind])*log10(1.0-pi[ind]);
     }
@@ -228,20 +228,20 @@ List fit_binreg_eigenqr(const NumericMatrix& X,
         Rcpp::checkUserInterrupt();  // check for ^C from user
 
         // fitted values using weighted XX; will need to divide by previous weights
-        nu = calc_fitted_linreg_eigenqr(XX, z, qr_tol);
+        eta = calc_fitted_linreg_eigenqr(XX, z, qr_tol);
 
         llik = 0.0;
         for(int ind=0; ind<n_ind; ind++) {
-            nu[ind] /= wt[ind]; // need to divide by previous weights
+            eta[ind] /= wt[ind]; // need to divide by previous weights
 
-            // don't let nu get too large or too small
-            if(nu[ind] < -nu_max) nu[ind] = -nu_max;
-            else if(nu[ind] > nu_max) nu[ind] = nu_max;
+            // don't let eta get too large or too small
+            if(eta[ind] < -eta_max) eta[ind] = -eta_max;
+            else if(eta[ind] > eta_max) eta[ind] = eta_max;
 
-            pi[ind] = exp(nu[ind])/(1.0 + exp(nu[ind]));
+            pi[ind] = exp(eta[ind])/(1.0 + exp(eta[ind]));
 
             wt[ind] = sqrt(pi[ind] * (1.0 - pi[ind]));
-            z[ind] = nu[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
+            z[ind] = eta[ind]*wt[ind] + (y[ind] - pi[ind])/wt[ind];
 
             llik += y[ind] * log10(pi[ind]) + (1.0-y[ind])*log10(1.0-pi[ind]);
         }

--- a/src/binreg_eigen.h
+++ b/src/binreg_eigen.h
@@ -9,12 +9,12 @@
 //
 // maxit = maximum number of iterations
 // tol = tolerance for convergence
-// nu_max = maximum value for linear predictor
+// eta_max = maximum value for linear predictor
 double calc_ll_binreg_eigenchol(const Rcpp::NumericMatrix& X,
                                 const Rcpp::NumericVector& y,
                                 const int maxit,
                                 const double tol,
-                                const double nu_max);
+                                const double eta_max);
 
 // logistic regression by Qr decomposition with column pivoting
 // return just the log likelihood
@@ -22,14 +22,14 @@ double calc_ll_binreg_eigenchol(const Rcpp::NumericMatrix& X,
 // maxit = maximum number of iterations
 // tol = tolerance for convergence
 // qr_tol = tolerance for QR decomposition
-// nu_max = maximum value for linear predictor
+// eta_max = maximum value for linear predictor
 //
 double calc_ll_binreg_eigenqr(const Rcpp::NumericMatrix& X,
                               const Rcpp::NumericVector& y,
                               const int maxit,
                               const double tol,
                               const double qr_tol,
-                              const double nu_max);
+                              const double eta_max);
 
 // logistic regression
 // return just the coefficients
@@ -38,7 +38,7 @@ Rcpp::NumericVector calc_coef_binreg_eigenqr(const Rcpp::NumericMatrix& X,
                                              const int maxit,      // max iterations
                                              const double tol,     // tolerance for convergence
                                              const double qr_tol,  // tolerance for QR decomp
-                                             const double nu_max); // max value for linear predictor
+                                             const double eta_max); // max value for linear predictor
 
 // logistic regression
 // return the coefficients and SEs
@@ -47,7 +47,7 @@ Rcpp::List calc_coefSE_binreg_eigenqr(const Rcpp::NumericMatrix& X,
                                       const int maxit,      // max iterations
                                       const double tol,     // tolerance for convergence
                                       const double qr_tol,  // tolerance for QR decomp
-                                      const double nu_max); // max value for linear predictor
+                                      const double eta_max); // max value for linear predictor
 
 // logistic regression
 // return (llik, individual contributions to llik, fitted probabilities, coef, SE
@@ -57,6 +57,6 @@ Rcpp::List fit_binreg_eigenqr(const Rcpp::NumericMatrix& X,
                               const int maxit,      // max iterations
                               const double tol,     // tolerance for convergence
                               const double qr_tol,  // tolerance for QR decomp
-                              const double nu_max); // max value for linear predictor
+                              const double eta_max); // max value for linear predictor
 
 #endif // BINREG_EIGEN_H

--- a/src/binreg_weighted.cpp
+++ b/src/binreg_weighted.cpp
@@ -16,9 +16,9 @@ using namespace Eigen;
 double calc_ll_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
                                const NumericVector &weights,
                                const int maxit=100, const double tol=1e-6,
-                               const double qr_tol=1e-12, const double nu_max=30.0)
+                               const double qr_tol=1e-12, const double eta_max=30.0)
 {
-    return calc_ll_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max);
+    return calc_ll_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, eta_max);
 }
 
 // logistic regression
@@ -28,9 +28,9 @@ double calc_ll_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
 NumericVector calc_coef_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
                                         const NumericVector &weights,
                                         const int maxit=100, const double tol=1e-6,
-                                        const double qr_tol=1e-12, const double nu_max=30.0)
+                                        const double qr_tol=1e-12, const double eta_max=30.0)
 {
-    return calc_coef_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max);
+    return calc_coef_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, eta_max);
 }
 
 // logistic regression
@@ -40,9 +40,9 @@ NumericVector calc_coef_binreg_weighted(const NumericMatrix& X, const NumericVec
 List calc_coefSE_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
                                  const NumericVector &weights,
                                  const int maxit=100, const double tol=1e-6,
-                                 const double qr_tol=1e-12, const double nu_max=30.0)
+                                 const double qr_tol=1e-12, const double eta_max=30.0)
 {
-    return calc_coefSE_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, nu_max);
+    return calc_coefSE_binreg_weighted_eigenqr(X, y, weights, maxit, tol, qr_tol, eta_max);
 }
 
 // logistic regression
@@ -53,7 +53,7 @@ List fit_binreg_weighted(const NumericMatrix& X, const NumericVector& y,
                          const NumericVector &weights,
                          const bool se=true, // whether to include SEs
                          const int maxit=100, const double tol=1e-6,
-                         const double qr_tol=1e-12, const double nu_max=30.0)
+                         const double qr_tol=1e-12, const double eta_max=30.0)
 {
-    return fit_binreg_weighted_eigenqr(X, y, weights, se, maxit, tol, qr_tol, nu_max);
+    return fit_binreg_weighted_eigenqr(X, y, weights, se, maxit, tol, qr_tol, eta_max);
 }

--- a/src/binreg_weighted.h
+++ b/src/binreg_weighted.h
@@ -13,7 +13,7 @@ double calc_ll_binreg_weighted(const Rcpp::NumericMatrix& X,
                                const int maxit,
                                const double tol,
                                const double qr_tol,
-                               const double nu_max);
+                               const double eta_max);
 
 // logistic regression
 // return just the coefficients
@@ -24,7 +24,7 @@ Rcpp::NumericVector calc_coef_binreg_weighted(const Rcpp::NumericMatrix& X,
                                               const int maxit,
                                               const double tol,
                                               const double qr_tol,
-                                              const double nu_max);
+                                              const double eta_max);
 
 // logistic regression
 // return the coefficients and SEs
@@ -35,7 +35,7 @@ Rcpp::List calc_coefSE_binreg_weighted(const Rcpp::NumericMatrix& X,
                                        const int maxit,
                                        const double tol,
                                        const double qr_tol,
-                                       const double nu_max);
+                                       const double eta_max);
 
 // logistic regression
 // return (llik, individual contributions to llik, fitted probabilities, coef, SE
@@ -47,6 +47,6 @@ Rcpp::List fit_binreg_weighted(const Rcpp::NumericMatrix& X,
                                const int maxit,
                                const double tol,
                                const double qr_tol,
-                               const double nu_max);
+                               const double eta_max);
 
 #endif // BINREG_WEIGHTED_H

--- a/src/binreg_weighted_eigen.h
+++ b/src/binreg_weighted_eigen.h
@@ -12,7 +12,7 @@ double calc_ll_binreg_weighted_eigenchol(const Rcpp::NumericMatrix& X,
                                          const Rcpp::NumericVector& weights,
                                          const int maxit,
                                          const double tol,
-                                         const double nu_max);
+                                         const double eta_max);
 
 // logistic regression by Qr decomposition with column pivoting
 // return just the log likelihood
@@ -23,7 +23,7 @@ double calc_ll_binreg_weighted_eigenqr(const Rcpp::NumericMatrix& X,
                                        const int maxit,
                                        const double tol,
                                        const double qr_tol,
-                                       const double nu_max);
+                                       const double eta_max);
 
 // logistic regression
 // return just the coefficients
@@ -34,7 +34,7 @@ Rcpp::NumericVector calc_coef_binreg_weighted_eigenqr(const Rcpp::NumericMatrix&
                                                       const int maxit,
                                                       const double tol,
                                                       const double qr_tol,
-                                                      const double nu_max);
+                                                      const double eta_max);
 
 // logistic regression
 // return the coefficients and SEs
@@ -45,7 +45,7 @@ Rcpp::List calc_coefSE_binreg_weighted_eigenqr(const Rcpp::NumericMatrix& X,
                                                const int maxit,
                                                const double tol,
                                                const double qr_tol,
-                                               const double nu_max);
+                                               const double eta_max);
 
 // logistic regression
 // return (llik, individual contributions to llik, fitted probabilities, coef, SE
@@ -57,6 +57,6 @@ Rcpp::List fit_binreg_weighted_eigenqr(const Rcpp::NumericMatrix& X,
                                        const int maxit,
                                        const double tol,
                                        const double qr_tol,
-                                       const double nu_max);
+                                       const double eta_max);
 
 #endif // BINREG_WEIGHTED_EIGEN_H

--- a/src/fit1_binary.cpp
+++ b/src/fit1_binary.cpp
@@ -28,7 +28,7 @@ List fit1_binary_addcovar(const NumericMatrix& genoprobs,
                           const int maxit=100,
                           const double tol=1e-6,
                           const double qr_tol=1e-12,
-                          const double nu_max=30.0)
+                          const double eta_max=30.0)
 {
     const int n_ind = pheno.size();
     const int n_gen = genoprobs.cols();
@@ -54,9 +54,9 @@ List fit1_binary_addcovar(const NumericMatrix& genoprobs,
         std::copy(addcovar.begin(), addcovar.end(), X.begin() + x_size);
 
     if(n_weights > 0)
-        return fit_binreg_weighted(X, pheno, weights, se, maxit, tol, qr_tol, nu_max);
+        return fit_binreg_weighted(X, pheno, weights, se, maxit, tol, qr_tol, eta_max);
     else
-        return fit_binreg(X, pheno, se, maxit, tol, qr_tol, nu_max);
+        return fit_binreg(X, pheno, se, maxit, tol, qr_tol, eta_max);
 }
 
 
@@ -81,7 +81,7 @@ List fit1_binary_intcovar(const NumericMatrix& genoprobs,
                           const int maxit=100,
                           const double tol=1e-6,
                           const double qr_tol=1e-12,
-                          const double nu_max=30.0)
+                          const double eta_max=30.0)
 {
     const int n_ind = pheno.size();
     const int n_weights = weights.size();
@@ -99,7 +99,7 @@ List fit1_binary_intcovar(const NumericMatrix& genoprobs,
     NumericMatrix X = formX_intcovar(genoprobs, addcovar, intcovar, 0, false);
 
     if(n_weights > 0)
-        return fit_binreg_weighted(X, pheno, weights, se, maxit, tol, qr_tol, nu_max);
+        return fit_binreg_weighted(X, pheno, weights, se, maxit, tol, qr_tol, eta_max);
     else
-        return fit_binreg(X, pheno, se, maxit, tol, qr_tol, nu_max);
+        return fit_binreg(X, pheno, se, maxit, tol, qr_tol, eta_max);
 }

--- a/src/fit1_binary.h
+++ b/src/fit1_binary.h
@@ -21,7 +21,7 @@ Rcpp::List fit1_binary_addcovar(const Rcpp::NumericMatrix& genoprobs,
                                 const int maxit,
                                 const double tol,
                                 const double qr_tol,
-                                const double nu_max);
+                                const double eta_max);
 
 
 // Fit a single-QTL model at a single position, with interactive covariates
@@ -41,6 +41,6 @@ Rcpp::List fit1_binary_intcovar(const Rcpp::NumericMatrix& genoprobs,
                                 const int maxit,
                                 const double tol,
                                 const double qr_tol,
-                                const double nu_max);
+                                const double eta_max);
 
 #endif // FIT1_BINARY_H

--- a/src/scan1_binary.cpp
+++ b/src/scan1_binary.cpp
@@ -26,7 +26,7 @@ NumericMatrix scan_binary_onechr(const NumericVector& genoprobs,
                                  const int maxit=100,
                                  const double tol=1e-6,
                                  const double qr_tol=1e-12,
-                                 const double nu_max=30.0)
+                                 const double eta_max=30.0)
 {
     const int n_ind = pheno.rows();
     const int n_phe = pheno.cols();
@@ -58,7 +58,7 @@ NumericMatrix scan_binary_onechr(const NumericVector& genoprobs,
 
         for(int phe=0; phe<n_phe; phe++) {
             // calc rss and paste into ith column of result
-            result(phe,pos) = calc_ll_binreg(X, pheno(_,phe), maxit, tol, qr_tol, nu_max);
+            result(phe,pos) = calc_ll_binreg(X, pheno(_,phe), maxit, tol, qr_tol, eta_max);
         }
     }
 
@@ -83,7 +83,7 @@ NumericMatrix scan_binary_onechr_weighted(const NumericVector& genoprobs,
                                           const int maxit=100,
                                           const double tol=1e-6,
                                           const double qr_tol=1e-12,
-                                          const double nu_max=30.0)
+                                          const double eta_max=30.0)
 {
     const int n_ind = pheno.rows();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -117,7 +117,7 @@ NumericMatrix scan_binary_onechr_weighted(const NumericVector& genoprobs,
 
         for(int phe=0; phe<n_phe; phe++) {
             // calc rss and paste into ith column of result
-            result(phe,pos) = calc_ll_binreg_weighted(X, pheno(_,phe), weights, maxit, tol, qr_tol, nu_max);
+            result(phe,pos) = calc_ll_binreg_weighted(X, pheno(_,phe), weights, maxit, tol, qr_tol, eta_max);
         }
     }
 
@@ -231,7 +231,7 @@ NumericMatrix scan_binary_onechr_intcovar_lowmem(const NumericVector& genoprobs,
                                                  const int maxit=100,
                                                  const double tol=1e-6,
                                                  const double qr_tol=1e-12,
-                                                 const double nu_max=30.0)
+                                                 const double eta_max=30.0)
 {
     const int n_ind = pheno.rows();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -258,7 +258,7 @@ NumericMatrix scan_binary_onechr_intcovar_lowmem(const NumericVector& genoprobs,
 
         for(int phe=0; phe<n_phe; phe++) {
             // do regression
-            result(phe,pos) = calc_ll_binreg(X, pheno(_,phe), maxit, tol, qr_tol, nu_max);
+            result(phe,pos) = calc_ll_binreg(X, pheno(_,phe), maxit, tol, qr_tol, eta_max);
         }
     }
 
@@ -288,7 +288,7 @@ NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const NumericVector& g
                                                           const int maxit=100,
                                                           const double tol=1e-6,
                                                           const double qr_tol=1e-12,
-                                                          const double nu_max=30.0)
+                                                          const double eta_max=30.0)
 {
     const int n_ind = pheno.rows();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -315,7 +315,7 @@ NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const NumericVector& g
 
         for(int phe=0; phe<n_phe; phe++) {
             // do regression
-            result(phe,pos) = calc_ll_binreg_weighted(X, pheno(_,phe), weights, maxit, tol, qr_tol, nu_max);
+            result(phe,pos) = calc_ll_binreg_weighted(X, pheno(_,phe), weights, maxit, tol, qr_tol, eta_max);
         }
     }
 

--- a/src/scan1_binary.h
+++ b/src/scan1_binary.h
@@ -18,7 +18,7 @@ Rcpp::NumericMatrix scan_binary_onechr(const Rcpp::NumericVector& genoprobs,
                                        const int maxit,
                                        const double tol,
                                        const double qr_tol,
-                                       const double nu_max);
+                                       const double eta_max);
 
 // Scan a single chromosome with additive covariates and weights
 //
@@ -36,7 +36,7 @@ Rcpp::NumericMatrix scan_binary_onechr_weighted(const Rcpp::NumericVector& genop
                                                 const int maxit,
                                                 const double tol,
                                                 const double qr_tol,
-                                                const double nu_max);
+                                                const double eta_max);
 
 // Scan a single chromosome with interactive covariates
 // this version should be fast but requires more memory
@@ -56,7 +56,7 @@ Rcpp::NumericMatrix scan_binary_onechr_intcovar_highmem(const Rcpp::NumericVecto
                                                         const int maxit,
                                                         const double tol,
                                                         const double qr_tol,
-                                                        const double nu_max);
+                                                        const double eta_max);
 
 // Scan a single chromosome with interactive covariates
 // this version should be fast but requires more memory
@@ -78,7 +78,7 @@ Rcpp::NumericMatrix scan_binary_onechr_intcovar_weighted_highmem(const Rcpp::Num
                                                                  const int maxit,
                                                                  const double tol,
                                                                  const double qr_tol,
-                                                                 const double nu_max);
+                                                                 const double eta_max);
 
 // Scan a single chromosome with interactive covariates
 // this version uses less memory but will be slower
@@ -98,7 +98,7 @@ Rcpp::NumericMatrix scan_binary_onechr_intcovar_lowmem(const Rcpp::NumericVector
                                                        const int maxit,
                                                        const double tol,
                                                        const double qr_tol,
-                                                       const double nu_max);
+                                                       const double eta_max);
 
 // Scan a single chromosome with interactive covariates
 // this version uses less memory but will be slower
@@ -121,6 +121,6 @@ Rcpp::NumericMatrix scan_binary_onechr_intcovar_weighted_lowmem(const Rcpp::Nume
                                                                 const int maxit,
                                                                 const double tol,
                                                                 const double qr_tol,
-                                                                const double nu_max);
+                                                                const double eta_max);
 
 #endif // SCAN_BINARY_H

--- a/src/scan1coef_binary.cpp
+++ b/src/scan1coef_binary.cpp
@@ -27,7 +27,7 @@ NumericMatrix scancoef_binary_addcovar(const NumericVector& genoprobs,
                                        const int maxit=100,
                                        const double tol=1e-6,
                                        const double qr_tol=1e-12,
-                                       const double nu_max=30.0)
+                                       const double eta_max=30.0)
 {
     const int n_ind = pheno.size();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -64,9 +64,9 @@ NumericMatrix scancoef_binary_addcovar(const NumericVector& genoprobs,
 
         // do regression
         if(n_weights > 0)
-            result(_,pos) = calc_coef_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, nu_max);
+            result(_,pos) = calc_coef_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, eta_max);
         else
-            result(_,pos) = calc_coef_binreg(X, pheno, maxit, tol, qr_tol, nu_max);
+            result(_,pos) = calc_coef_binreg(X, pheno, maxit, tol, qr_tol, eta_max);
     }
 
     return result;
@@ -93,7 +93,7 @@ NumericMatrix scancoef_binary_intcovar(const NumericVector& genoprobs,
                                        const int maxit=100,
                                        const double tol=1e-6,
                                        const double qr_tol=1e-12,
-                                       const double nu_max=30.0)
+                                       const double eta_max=30.0)
 {
     const int n_ind = pheno.size();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -126,9 +126,9 @@ NumericMatrix scancoef_binary_intcovar(const NumericVector& genoprobs,
 
         // do regression
         if(n_weights > 0)
-            result(_,pos) = calc_coef_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, nu_max);
+            result(_,pos) = calc_coef_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, eta_max);
         else
-            result(_,pos) = calc_coef_binreg(X, pheno, maxit, tol, qr_tol, nu_max);
+            result(_,pos) = calc_coef_binreg(X, pheno, maxit, tol, qr_tol, eta_max);
     }
 
     return result;
@@ -153,7 +153,7 @@ List scancoefSE_binary_addcovar(const NumericVector& genoprobs,
                                 const int maxit=100,
                                 const double tol=1e-6,
                                 const double qr_tol=1e-12,
-                                const double nu_max=30.0)
+                                const double eta_max=30.0)
 {
     const int n_ind = pheno.size();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -192,9 +192,9 @@ List scancoefSE_binary_addcovar(const NumericVector& genoprobs,
         // do regression
         List tmp;
         if(n_weights > 0)
-            tmp = calc_coefSE_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, nu_max);
+            tmp = calc_coefSE_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, eta_max);
         else
-            tmp = calc_coefSE_binreg(X, pheno, maxit, tol, qr_tol, nu_max);
+            tmp = calc_coefSE_binreg(X, pheno, maxit, tol, qr_tol, eta_max);
         NumericVector tmpcoef = tmp[0];
         NumericVector tmpse = tmp[1];
         coef(_,pos) = tmpcoef;
@@ -226,7 +226,7 @@ List scancoefSE_binary_intcovar(const NumericVector& genoprobs,
                                 const int maxit=100,
                                 const double tol=1e-6,
                                 const double qr_tol=1e-12,
-                                const double nu_max=30.0)
+                                const double eta_max=30.0)
 {
     const int n_ind = pheno.size();
     if(Rf_isNull(genoprobs.attr("dim")))
@@ -261,9 +261,9 @@ List scancoefSE_binary_intcovar(const NumericVector& genoprobs,
         // do regression
         List tmp;
         if(n_weights > 0)
-            tmp = calc_coefSE_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, nu_max);
+            tmp = calc_coefSE_binreg_weighted(X, pheno, weights, maxit, tol, qr_tol, eta_max);
         else
-            tmp = calc_coefSE_binreg(X, pheno, maxit, tol, qr_tol, nu_max);
+            tmp = calc_coefSE_binreg(X, pheno, maxit, tol, qr_tol, eta_max);
         NumericVector tmpcoef = tmp[0];
         NumericVector tmpse = tmp[1];
         coef(_,pos) = tmpcoef;

--- a/src/scan1coef_binary.h
+++ b/src/scan1coef_binary.h
@@ -20,7 +20,7 @@ Rcpp::NumericMatrix scancoef_binary_addcovar(const Rcpp::NumericVector& genoprob
                                              const int maxit,
                                              const double tol,
                                              const double qr_tol,
-                                             const double nu_max);
+                                             const double eta_max);
 
 // Scan a single chromosome to calculate coefficients, with interactive covariates
 //
@@ -40,7 +40,7 @@ Rcpp::NumericMatrix scancoef_binary_intcovar(const Rcpp::NumericVector& genoprob
                                              const int maxit,
                                              const double tol,
                                              const double qr_tol,
-                                             const double nu_max);
+                                             const double eta_max);
 
 // Scan a single chromosome to calculate coefficients, with additive covariates
 //
@@ -58,7 +58,7 @@ Rcpp::List scancoefSE_binary_addcovar(const Rcpp::NumericVector& genoprobs,
                                       const int maxit,
                                       const double tol,
                                       const double qr_tol,
-                                      const double nu_max);
+                                      const double eta_max);
 
 
 // Scan a single chromosome to calculate coefficients, with interactive covariates
@@ -79,6 +79,6 @@ Rcpp::List scancoefSE_binary_intcovar(const Rcpp::NumericVector& genoprobs,
                                       const int maxit,
                                       const double tol,
                                       const double qr_tol,
-                                      const double nu_max);
+                                      const double eta_max);
 
 #endif // SCAN1COEF_BINARY_H

--- a/tests/testthat/test-scan1snps.R
+++ b/tests/testthat/test-scan1snps.R
@@ -139,7 +139,7 @@ test_that("scan1snps works", {
     # binary trait with weights
     w <- ceiling(w) # avoid warning from glm() about weights not being integers
     outbinw <- scan1snps(probs, DOex$pmap, binphe, query_func=queryf, chr=2, start=97.2, end=97.3,
-                         model="binary", weights=w, nu_max=25, maxit=1000, tol=1e-5)
+                         model="binary", weights=w, eta_max=25, maxit=1000, tol=1e-5)
 
     out_glm <- glm(biny ~ -1 + p, family=binomial(link=logit), weights=w)
     out_glm0 <- glm(biny ~ 1, family=binomial(link=logit), weights=w)


### PR DESCRIPTION
- In the code for binary traits, fitting logistic regressions, I called the linear predictor "nu", but I really should have called it "eta", to conform with the notation in McCullagh and Nelder (and base R functions like glm.fit). So now I've replaced all nu's with eta's.