### PR TITLE
Label plot_peaks() with LOD scores

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.17-10
-Date: 2019-01-12
+Version: 0.17-11
+Date: 2019-01-22
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2 0.17-10 (2019-01-12)
+## qtl2 0.17-11 (2019-01-22)
 
 ### New features
 
@@ -21,6 +21,9 @@
   It's for combining matrices using row names to align the rows and
   expanding with missing values if there are rows in some matrices but
   not others.
+
+- In `plot_peaks()`, added `lod_labels` argument. If TRUE, include LOD
+  scores as text labels in the figure.
 
 ### Minor changes
 

--- a/R/myround.R
+++ b/R/myround.R
@@ -1,0 +1,20 @@
+# Round a number, preserving extra 0's. (taken from R/broman, https://github.com/kbroman/broman)
+myround <-
+    function(x, digits=1)
+{
+    if(digits < 1)
+        stop("This is intended for the case digits >= 1.")
+
+    if(length(digits) > 1) {
+        digits <- digits[1]
+        warning("Using only digits[1]")
+    }
+
+    tmp <- sprintf(paste("%.", digits, "f", sep=""), x)
+
+    # deal with "-0.00" case
+    zero <- paste0("0.", paste(rep("0", digits), collapse=""))
+    tmp[tmp == paste0("-", zero)] <- zero
+
+    tmp
+}

--- a/R/plot_peaks.R
+++ b/R/plot_peaks.R
@@ -15,6 +15,12 @@
 #'     strings.
 #' @param tick_height Height of tick marks at the peaks (a number between 0 and 1).
 #' @param gap Gap between chromosomes.
+#' @param lod_labels If TRUE, plot LOD scores near the intervals. Uses
+#'     three hidden graphics parameters, `label_gap` (distance between
+#'     CI and LOD text label), `label_left` (vector that indicates
+#'     whether the labels should go on the left side; TRUE=on left,
+#'     FALSE=on right, NA=put into larger gap on that chromosome), and
+#'     `label_cex` that controls the size of these labels
 #' @param ... Additional graphics parameters
 #'
 #' @seealso [find_peaks()], [plot_lodpeaks()]
@@ -55,10 +61,16 @@
 #' peaks <- find_peaks(out, map, threshold=3.5, drop=1.5)
 #'
 #' plot_peaks(peaks, map)
-
+#'
+#' # show LOD scores
+#' plot_peaks(peaks, map, lod_labels=TRUE)
+#'
+#' # show LOD scores, controlling whether they go on the left or right
+#' plot_peaks(peaks, map, lod_labels=TRUE,
+#'            label_left=c(TRUE, TRUE, TRUE, FALSE, TRUE, FALSE))
 plot_peaks <-
     function(peaks, map, chr=NULL, tick_height = 0.3,
-             gap=25, ...)
+             gap=25, lod_labels=FALSE, ...)
 {
     if(is.null(peaks)) stop("peaks is NULL")
     if(is.null(map)) stop("map is NULL")
@@ -88,7 +100,8 @@ plot_peaks <-
                  mgp=NULL, las=1, lend=1, ljoin=1,
                  hlines=NULL, hlines_col="white", hlines_lwd=1, hlines_lty=1,
                  vlines=NULL, vlines_col="white", vlines_lwd=1, vlines_lty=1,
-                 sub="", ...)
+                 sub="", lod_labels=FALSE, label_left=NULL, label_gap=NULL,
+                 label_cex=NULL, label_col=NULL, ...)
         {
             dots <- list(...)
             onechr <- (length(map)==1) # single chromosome
@@ -187,9 +200,106 @@ plot_peaks <-
                          lend=lend, ljoin=ljoin)
             }
 
-        }
+            # add lod labels
+            if(lod_labels) {
+                add_lod_labels(peaks, map, gap=gap,
+                               label_left=label_left, label_gap=label_gap,
+                               label_cex=label_cex, label_col=label_col)
+            }
+
+        } # end of internal function
 
     plot_peaks_internal(peaks=peaks, map=map, tick_height=tick_height,
-                        gap=gap, ...)
+                        gap=gap, lod_labels=lod_labels, ...)
 
 }
+
+
+# Add LOD scores as text labels
+add_lod_labels <-
+    function(peaks, map, gap=25,
+             label_left=NULL, label_gap=NULL,
+             label_cex=NULL, label_col=NULL)
+    {
+        # end points of CIs
+        if("ci_lo" %in% names(peaks) && "ci_hi" %in% names(peaks)) {
+            ci_lo <- peaks$ci_lo
+            ci_hi <- peaks$ci_hi
+        } else {
+            ci_lo <- ci_hi <- peaks$pos
+        }
+
+        # x and y positions
+        x_lo <- xpos_scan1(map, names(map), gap, peaks$chr, ci_lo)
+        x_hi <- xpos_scan1(map, names(map), gap, peaks$chr, ci_hi)
+
+        unique_lodindex <- sort(unique(peaks$lodindex))
+        y <- match(peaks$lodindex, unique_lodindex)
+
+        # determine whether they go on the left or right
+        chr_start <- vapply(map, min, na.rm=TRUE, 0.0)[peaks$chr]
+        chr_end <- vapply(map, max, na.rm=TRUE, 0.0)[peaks$chr]
+        left_gap <- ci_lo - chr_start
+        right_gap <- chr_end - ci_hi
+
+        if(is.null(label_left)) {
+            label_left <- rep(NA, nrow(peaks))
+        } else if(length(label_left) != nrow(peaks)) {
+            if(length(label_left) < nrow(peaks)) {
+                label_left <- rep(label_left, nrow(peaks))
+            }
+            label_left <- label_left[seq_len(nrow(peaks))]
+        }
+        if(any(is.na(label_left))) {
+            wh <- which(is.na(label_left))
+            label_left[wh] <- TRUE
+            label_left[wh][right_gap[wh] > left_gap[wh]] <- FALSE
+        }
+
+        # expand label_gap to vector
+        if(is.null(label_gap)) {
+            label_gap <- gap/2
+        }
+        if(length(label_gap) != nrow(peaks)) {
+            if(length(label_gap) < nrow(peaks)) {
+                label_gap <- rep(label_gap, nrow(peaks))
+            }
+            label_gap <- label_gap[seq_len(nrow(peaks))]
+        }
+        # expand label_cex to vector
+        if(is.null(label_cex)) {
+            label_cex <- par("cex")
+        }
+        if(length(label_cex) != nrow(peaks)) {
+            if(length(label_cex) < nrow(peaks)) {
+                label_cex <- rep(label_cex, nrow(peaks))
+            }
+            label_cex <- label_cex[seq_len(nrow(peaks))]
+        }
+        # expand label_col to vector
+        if(is.null(label_col)) {
+            label_col <- par("fg")
+        }
+        if(length(label_col) != nrow(peaks)) {
+            if(length(label_col) < nrow(peaks)) {
+                label_col <- rep(label_col, nrow(peaks))
+            }
+            label_col <- label_col[seq_len(nrow(peaks))]
+        }
+
+        # position for text
+        label_gap[label_left] <- -label_gap[label_left]
+        x <- peaks$ci_hi
+        label_adj <- rep(0, nrow(peaks))
+        if(any(label_left)) {
+            x[label_left] <- peaks$ci_lo[label_left]
+            label_adj[label_left] <- 1
+        }
+        x <- xpos_scan1(map, names(map), gap, peaks$chr, x) + label_gap
+
+        # add the text
+        for(i in seq_len(nrow(peaks))) {
+            text(x[i], y[i], myround(peaks$lod[i], 1),
+                 label_adj[i], cex=label_cex[i], col=label_col[i])
+        }
+    }

--- a/man/plot_peaks.Rd
+++ b/man/plot_peaks.Rd
@@ -4,7 +4,8 @@
 \alias{plot_peaks}
 \title{Plot QTL peak locations}
 \usage{
-plot_peaks(peaks, map, chr = NULL, tick_height = 0.3, gap = 25, ...)
+plot_peaks(peaks, map, chr = NULL, tick_height = 0.3, gap = 25,
+  lod_labels = FALSE, ...)
 }
 \arguments{
 \item{peaks}{Data frame such as that produced by
@@ -22,6 +23,13 @@ strings.}
 \item{tick_height}{Height of tick marks at the peaks (a number between 0 and 1).}
 
 \item{gap}{Gap between chromosomes.}
+
+\item{lod_labels}{If TRUE, plot LOD scores near the intervals. Uses
+three hidden graphics parameters, \code{label_gap} (distance between
+CI and LOD text label), \code{label_left} (vector that indicates
+whether the labels should go on the left side; TRUE=on left,
+FALSE=on right, NA=put into larger gap on that chromosome), and
+\code{label_cex} that controls the size of these labels}
 
 \item{...}{Additional graphics parameters}
 }
@@ -64,6 +72,13 @@ out <- scan1(probs, pheno, addcovar=covar, Xcovar=Xcovar)
 peaks <- find_peaks(out, map, threshold=3.5, drop=1.5)
 
 plot_peaks(peaks, map)
+
+# show LOD scores
+plot_peaks(peaks, map, lod_labels=TRUE)
+
+# show LOD scores, controlling whether they go on the left or right
+plot_peaks(peaks, map, lod_labels=TRUE,
+           label_left=c(TRUE, TRUE, TRUE, FALSE, TRUE, FALSE))
 }
 \seealso{
 \code{\link[=find_peaks]{find_peaks()}}, \code{\link[=plot_lodpeaks]{plot_lodpeaks()}}


### PR DESCRIPTION
In `plot_peaks()`, add argument `lod_labels`. If TRUE, include LOD scores as text labels in the figure.
Implements Issue #94 