### PR TITLE
Change default gap between chromosomes in plot_scan1() and related

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,9 @@
 - `rbind_scan1()` and `cbind_scan1()` no longer give error if inputs
   don't all have matching attributes.
 
+- Change default gap between chromosomes in `plot_scan1()` (and
+  related) to be 1% of the total genome length.
+
 ### Bug fixes
 
 - Fixed bug in `subset_kinship()` that prevented `scan1()` from

--- a/R/add_threshold.R
+++ b/R/add_threshold.R
@@ -10,7 +10,7 @@
 #' `"X"` component is taken to be `thresholdX`.)
 #' @param thresholdX X chromosome threshold (if missing, assumed to be the same as `thresholdA`)
 #' @param chr Chromosomes that were included in the plot
-#' @param gap Gap between chromosomes in the plot. Default is 1% of the total genome length.
+#' @param gap Gap between chromosomes in the plot. Default is 1\% of the total genome length.
 #' @param ... Additional arguments passed to [graphics::segments()]
 #'
 #' @examples

--- a/R/add_threshold.R
+++ b/R/add_threshold.R
@@ -10,7 +10,7 @@
 #' `"X"` component is taken to be `thresholdX`.)
 #' @param thresholdX X chromosome threshold (if missing, assumed to be the same as `thresholdA`)
 #' @param chr Chromosomes that were included in the plot
-#' @param gap Gap between chromosomes in the plot
+#' @param gap Gap between chromosomes in the plot. Default is 1% of the total genome length.
 #' @param ... Additional arguments passed to [graphics::segments()]
 #'
 #' @examples
@@ -31,8 +31,10 @@
 #' @importFrom stats setNames
 #' @export
 add_threshold <-
-    function(map, thresholdA, thresholdX=NULL, chr=NULL, gap=25, ...)
+    function(map, thresholdA, thresholdX=NULL, chr=NULL, gap=NULL, ...)
 {
+    if(is.null(gap)) gap <- sum(chr_lengths(map))/100
+
     if(is.list(thresholdA)) {
         thresholdX <- thresholdA$X
         thresholdA <- thresholdA$A

--- a/R/plot_coef.R
+++ b/R/plot_coef.R
@@ -78,7 +78,7 @@
 #' plot(coef, map[7], columns=1:3, col=c("slateblue", "violetred", "green3"))
 plot_coef <-
     function(x, map, columns=NULL, col=NULL, scan1_output=NULL,
-             add=FALSE, gap=25, top_panel_prop=0.65,
+             add=FALSE, gap=NULL, top_panel_prop=0.65,
              legend=NULL, ...)
 {
     if(is.null(map)) stop("map is NULL")
@@ -88,7 +88,6 @@ plot_coef <-
     x <- tmp$scan1
     map <- tmp$map
 
-    if(!is_nonneg_number(gap)) stop("gap should be a single non-negative number")
     if(!is_pos_number(top_panel_prop)) stop("top_panel_prop should be a single non-negative number")
 
     if(nrow(x) != length(unlist(map)))
@@ -157,7 +156,7 @@ plot_coef <-
 #' @export
 #' @rdname plot_coef
 plot_coefCC <-
-    function(x, map, columns=1:8, scan1_output=NULL, add=FALSE, gap=25,
+    function(x, map, columns=1:8, scan1_output=NULL, add=FALSE, gap=NULL,
              top_panel_prop=0.65, legend=NULL, ...)
 {
     plot_coef(x, map, columns=columns, col=qtl2::CCcolors[columns],
@@ -168,7 +167,7 @@ plot_coefCC <-
 #' @export
 #' @rdname plot_coef
 plot.scan1coef <-
-    function(x, map, columns=1, col=NULL, scan1_output=NULL, add=FALSE, gap=25,
+    function(x, map, columns=1, col=NULL, scan1_output=NULL, add=FALSE, gap=NULL,
              top_panel_prop=0.65, legend=NULL, ...)
 {
     plot_coef(x, map, columns=columns, col=col, scan1_output=scan1_output,

--- a/R/plot_coef.R
+++ b/R/plot_coef.R
@@ -22,7 +22,7 @@
 #' @param add If TRUE, add to current plot (must have same map and
 #' chromosomes).
 #'
-#' @param gap Gap between chromosomes.
+#' @param gap Gap between chromosomes. The default is 1\% of the total genome length.
 #'
 #' @param top_panel_prop If `scan1_output` provided, this gives the
 #' proportion of the plot that is devoted to the top panel.

--- a/R/plot_coef_and_lod.R
+++ b/R/plot_coef_and_lod.R
@@ -5,7 +5,7 @@
 # internal function that is called by plot_coef
 plot_coef_and_lod <-
     function(x, map, columns=NULL, col=NULL, scan1_output,
-             gap=25, top_panel_prop=0.65, legend=NULL,
+             gap=NULL, top_panel_prop=0.65, legend=NULL,
              ylim=NULL, bgcolor="gray90", altbgcolor="gray85",
              ylab="QTL effects",
              ylab_lod="LOD score", ylim_lod=NULL, col_lod="slateblue",

--- a/R/plot_lodpeaks.R
+++ b/R/plot_lodpeaks.R
@@ -13,7 +13,7 @@
 #'     and end positions).
 #' @param chr Selected chromosomes to plot; a vector of character
 #'     strings.
-#' @param gap Gap between chromosomes. The default is 1% of the total genome length.
+#' @param gap Gap between chromosomes. The default is 1\% of the total genome length.
 #' @param intervals If TRUE and `peaks` contains QTL intervals, plot the intervals.
 #' @param ... Additional graphics parameters
 #'

--- a/R/plot_lodpeaks.R
+++ b/R/plot_lodpeaks.R
@@ -13,7 +13,7 @@
 #'     and end positions).
 #' @param chr Selected chromosomes to plot; a vector of character
 #'     strings.
-#' @param gap Gap between chromosomes.
+#' @param gap Gap between chromosomes. The default is 1% of the total genome length.
 #' @param intervals If TRUE and `peaks` contains QTL intervals, plot the intervals.
 #' @param ... Additional graphics parameters
 #'
@@ -57,12 +57,10 @@
 #' plot_lodpeaks(peaks, map)
 
 plot_lodpeaks <-
-    function(peaks, map, chr=NULL, gap=25, intervals=FALSE, ...)
+    function(peaks, map, chr=NULL, gap=NULL, intervals=FALSE, ...)
 {
     if(is.null(peaks)) stop("peaks is NULL")
     if(is.null(map)) stop("map is NULL")
-
-    if(!is_nonneg_number(gap)) stop("gap should be a non-negative number")
 
     if(!is.list(map)) map <- list(" "=map) # if a vector, treat it as a list with no names
 

--- a/R/plot_peaks.R
+++ b/R/plot_peaks.R
@@ -14,7 +14,7 @@
 #' @param chr Selected chromosomes to plot; a vector of character
 #'     strings.
 #' @param tick_height Height of tick marks at the peaks (a number between 0 and 1).
-#' @param gap Gap between chromosomes.
+#' @param gap Gap between chromosomes. The default is 1% of the total genome length.
 #' @param lod_labels If TRUE, plot LOD scores near the intervals. Uses
 #'     three hidden graphics parameters, `label_gap` (distance between
 #'     CI and LOD text label), `label_left` (vector that indicates
@@ -70,10 +70,11 @@
 #'            label_left=c(TRUE, TRUE, TRUE, FALSE, TRUE, FALSE))
 plot_peaks <-
     function(peaks, map, chr=NULL, tick_height = 0.3,
-             gap=25, lod_labels=FALSE, ...)
+             gap=NULL, lod_labels=FALSE, ...)
 {
     if(is.null(peaks)) stop("peaks is NULL")
     if(is.null(map)) stop("map is NULL")
+    if(is.null(gap)) gap <- sum(chr_lengths(map))/100
 
     if(!is_nonneg_number(gap)) stop("gap should be a non-negative number")
     if(!is_nonneg_number(tick_height)) stop("tick_height should be a non-negative number")
@@ -217,7 +218,7 @@ plot_peaks <-
 
 # Add LOD scores as text labels
 add_lod_labels <-
-    function(peaks, map, gap=25,
+    function(peaks, map, gap,
              label_left=NULL, label_gap=NULL,
              label_cex=NULL, label_col=NULL)
     {

--- a/R/plot_peaks.R
+++ b/R/plot_peaks.R
@@ -14,7 +14,7 @@
 #' @param chr Selected chromosomes to plot; a vector of character
 #'     strings.
 #' @param tick_height Height of tick marks at the peaks (a number between 0 and 1).
-#' @param gap Gap between chromosomes. The default is 1% of the total genome length.
+#' @param gap Gap between chromosomes. The default is 1\% of the total genome length.
 #' @param lod_labels If TRUE, plot LOD scores near the intervals. Uses
 #'     three hidden graphics parameters, `label_gap` (distance between
 #'     CI and LOD text label), `label_left` (vector that indicates

--- a/R/plot_scan1.R
+++ b/R/plot_scan1.R
@@ -18,7 +18,7 @@
 #' @param add If TRUE, add to current plot (must have same map and
 #' chromosomes).
 #'
-#' @param gap Gap between chromosomes. The default is 1% of the total genome length.
+#' @param gap Gap between chromosomes. The default is 1\% of the total genome length.
 #'
 #' @param ... Additional graphics parameters.
 #'

--- a/R/plot_scan1.R
+++ b/R/plot_scan1.R
@@ -18,7 +18,7 @@
 #' @param add If TRUE, add to current plot (must have same map and
 #' chromosomes).
 #'
-#' @param gap Gap between chromosomes.
+#' @param gap Gap between chromosomes. The default is 1% of the total genome length.
 #'
 #' @param ... Additional graphics parameters.
 #'
@@ -73,7 +73,7 @@
 #' plot(out, map, lodcolumn="liver", ylim=ylim)
 #' plot(out, map, lodcolumn="spleen", col="violetred", add=TRUE)
 plot_scan1 <-
-    function(x, map, lodcolumn=1, chr=NULL, add=FALSE, gap=25, ...)
+    function(x, map, lodcolumn=1, chr=NULL, add=FALSE, gap=NULL, ...)
 {
     if(is.null(map)) stop("map is NULL")
 
@@ -88,6 +88,7 @@ plot_scan1 <-
         map <- map[chri]
     }
 
+    if(is.null(gap)) gap <- sum(chr_lengths(map))/100
     if(!is_nonneg_number(gap)) stop("gap should be a single non-negative number")
 
     # align scan1 output and map
@@ -117,7 +118,7 @@ plot_scan1 <-
     # internal function; trick to be able to pull things out of "..."
     #    but still have some defaults for them
     plot_scan1_internal <-
-        function(map, lod, add=FALSE, gap,
+        function(map, lod, add=FALSE, gap=NULL,
                  bgcolor="gray90", altbgcolor="gray85",
                  lwd=2, col="darkslateblue", altcol=NULL,
                  xlab=NULL, ylab="LOD score",
@@ -232,7 +233,7 @@ plot_scan1 <-
 #' @export
 #' @rdname plot_scan1
 plot.scan1 <-
-    function(x, map, lodcolumn=1, chr=NULL, add=FALSE, gap=25, ...)
+    function(x, map, lodcolumn=1, chr=NULL, add=FALSE, gap=NULL, ...)
 {
     if(is.null(map)) stop("map is NULL")
 
@@ -248,8 +249,10 @@ plot.scan1 <-
 
 # convert map to x-axis positions for plot_scan1
 map_to_xpos <-
-    function(map, gap)
+    function(map, gap=NULL)
 {
+    if(is.null(gap)) sum(chr_lengths(map))/100
+
     if(length(map)==1) return(map[[1]])
 
     chr_range <- vapply(map, range, c(0,1), na.rm=TRUE)
@@ -266,8 +269,10 @@ map_to_xpos <-
 # first row: left edges
 # second row: right edges
 map_to_boundaries <-
-    function(map, gap)
+    function(map, gap=NULL)
 {
+    if(is.null(gap)) gap <- sum(chr_lengths(map))/100
+
     if(length(map)==1)
         return(cbind(range(map[[1]], na.rm=TRUE)))
 

--- a/R/plot_snpasso.R
+++ b/R/plot_snpasso.R
@@ -48,7 +48,7 @@
 #'
 #' @param col Color of other points
 #'
-#' @param gap Gap between chromosomes. The default is 1% of the total genome length.
+#' @param gap Gap between chromosomes. The default is 1\% of the total genome length.
 #'
 #' @param minlod Minimum LOD to display. (Mostly for GWAS, in which
 #'     case using `minlod=1` will greatly increase the plotting speed,

--- a/R/plot_snpasso.R
+++ b/R/plot_snpasso.R
@@ -48,7 +48,7 @@
 #'
 #' @param col Color of other points
 #'
-#' @param gap Gap between chromosomes.
+#' @param gap Gap between chromosomes. The default is 1% of the total genome length.
 #'
 #' @param minlod Minimum LOD to display. (Mostly for GWAS, in which
 #'     case using `minlod=1` will greatly increase the plotting speed,
@@ -115,12 +115,10 @@
 plot_snpasso <-
     function(scan1output, snpinfo, genes=NULL, lodcolumn=1, show_all_snps=TRUE, chr=NULL,
              add=FALSE, drop_hilit=NA, col_hilit="violetred", col="darkslateblue",
-             gap=25, minlod=0, ...)
+             gap=NULL, minlod=0, ...)
 {
     if(is.null(scan1output)) stop("scan1output is NULL")
     if(is.null(snpinfo)) stop("snpinfo is NULL")
-
-    if(!is_nonneg_number(gap)) stop("gap should be a single non-negative number")
     if(!is_nonneg_number(minlod)) stop("minlod should be a single non-negative number")
 
     # pull out lod scores

--- a/R/plot_snpasso_and_genes.R
+++ b/R/plot_snpasso_and_genes.R
@@ -6,7 +6,7 @@
 plot_snpasso_and_genes <-
     function(scan1output, snpinfo, show_all_snps=TRUE,
              drop_hilit=NA, col_hilit="violetred", col="darkslateblue",
-             gap=25, minlod=0,
+             gap=NULL, minlod=0,
              genes, minrow=4, padding=0.2,
              colors=c("black", "red3", "green4", "blue3", "orange"),
              scale_pos=1, start_field="start", stop_field="stop",

--- a/R/xpos_scan1.R
+++ b/R/xpos_scan1.R
@@ -64,10 +64,10 @@
 #' # plot points
 #' points(xpos, peaks$lod, pch=21, bg=ptcolor)
 xpos_scan1 <-
-function(map, chr=NULL, gap=25, thechr, thepos)
+function(map, chr=NULL, gap=NULL, thechr, thepos)
 {
     if(is.null(map)) stop("map is NULL")
-    if(!is_nonneg_number(gap)) stop("gap should be a single non-negative number")
+    if(is.null(gap)) gap <- sum(chr_lengths(map))/100
 
     # subset chromosomes
     if(!is.null(chr)) map <- map[chr]

--- a/man/add_threshold.Rd
+++ b/man/add_threshold.Rd
@@ -5,7 +5,7 @@
 \title{Add thresholds to genome scan plot}
 \usage{
 add_threshold(map, thresholdA, thresholdX = NULL, chr = NULL,
-  gap = 25, ...)
+  gap = NULL, ...)
 }
 \arguments{
 \item{map}{Marker map used in the genome scan plot}
@@ -18,7 +18,7 @@ list, the \code{"A"} component is taken to be \code{thresholdA} and the
 
 \item{chr}{Chromosomes that were included in the plot}
 
-\item{gap}{Gap between chromosomes in the plot}
+\item{gap}{Gap between chromosomes in the plot. Default is 1% of the total genome length.}
 
 \item{...}{Additional arguments passed to \code{\link[graphics:segments]{graphics::segments()}}}
 }

--- a/man/add_threshold.Rd
+++ b/man/add_threshold.Rd
@@ -18,7 +18,7 @@ list, the \code{"A"} component is taken to be \code{thresholdA} and the
 
 \item{chr}{Chromosomes that were included in the plot}
 
-\item{gap}{Gap between chromosomes in the plot. Default is 1% of the total genome length.}
+\item{gap}{Gap between chromosomes in the plot. Default is 1\% of the total genome length.}
 
 \item{...}{Additional arguments passed to \code{\link[graphics:segments]{graphics::segments()}}}
 }

--- a/man/plot_coef.Rd
+++ b/man/plot_coef.Rd
@@ -36,7 +36,7 @@ score column; if multiple, only the first is used.}
 \item{add}{If TRUE, add to current plot (must have same map and
 chromosomes).}
 
-\item{gap}{Gap between chromosomes.}
+\item{gap}{Gap between chromosomes. The default is 1\% of the total genome length.}
 
 \item{top_panel_prop}{If \code{scan1_output} provided, this gives the
 proportion of the plot that is devoted to the top panel.}

--- a/man/plot_coef.Rd
+++ b/man/plot_coef.Rd
@@ -7,13 +7,14 @@
 \title{Plot QTL effects along chromosome}
 \usage{
 plot_coef(x, map, columns = NULL, col = NULL, scan1_output = NULL,
-  add = FALSE, gap = 25, top_panel_prop = 0.65, legend = NULL, ...)
+  add = FALSE, gap = NULL, top_panel_prop = 0.65, legend = NULL,
+  ...)
 
 plot_coefCC(x, map, columns = 1:8, scan1_output = NULL, add = FALSE,
-  gap = 25, top_panel_prop = 0.65, legend = NULL, ...)
+  gap = NULL, top_panel_prop = 0.65, legend = NULL, ...)
 
 \method{plot}{scan1coef}(x, map, columns = 1, col = NULL,
-  scan1_output = NULL, add = FALSE, gap = 25,
+  scan1_output = NULL, add = FALSE, gap = NULL,
   top_panel_prop = 0.65, legend = NULL, ...)
 }
 \arguments{

--- a/man/plot_lodpeaks.Rd
+++ b/man/plot_lodpeaks.Rd
@@ -20,7 +20,7 @@ and end positions).}
 \item{chr}{Selected chromosomes to plot; a vector of character
 strings.}
 
-\item{gap}{Gap between chromosomes. The default is 1% of the total genome length.}
+\item{gap}{Gap between chromosomes. The default is 1\% of the total genome length.}
 
 \item{intervals}{If TRUE and \code{peaks} contains QTL intervals, plot the intervals.}
 

--- a/man/plot_lodpeaks.Rd
+++ b/man/plot_lodpeaks.Rd
@@ -4,7 +4,7 @@
 \alias{plot_lodpeaks}
 \title{Plot LOD scores vs QTL peak locations}
 \usage{
-plot_lodpeaks(peaks, map, chr = NULL, gap = 25, intervals = FALSE,
+plot_lodpeaks(peaks, map, chr = NULL, gap = NULL, intervals = FALSE,
   ...)
 }
 \arguments{
@@ -20,7 +20,7 @@ and end positions).}
 \item{chr}{Selected chromosomes to plot; a vector of character
 strings.}
 
-\item{gap}{Gap between chromosomes.}
+\item{gap}{Gap between chromosomes. The default is 1% of the total genome length.}
 
 \item{intervals}{If TRUE and \code{peaks} contains QTL intervals, plot the intervals.}
 

--- a/man/plot_peaks.Rd
+++ b/man/plot_peaks.Rd
@@ -4,7 +4,7 @@
 \alias{plot_peaks}
 \title{Plot QTL peak locations}
 \usage{
-plot_peaks(peaks, map, chr = NULL, tick_height = 0.3, gap = 25,
+plot_peaks(peaks, map, chr = NULL, tick_height = 0.3, gap = NULL,
   lod_labels = FALSE, ...)
 }
 \arguments{
@@ -22,7 +22,7 @@ strings.}
 
 \item{tick_height}{Height of tick marks at the peaks (a number between 0 and 1).}
 
-\item{gap}{Gap between chromosomes.}
+\item{gap}{Gap between chromosomes. The default is 1% of the total genome length.}
 
 \item{lod_labels}{If TRUE, plot LOD scores near the intervals. Uses
 three hidden graphics parameters, \code{label_gap} (distance between

--- a/man/plot_peaks.Rd
+++ b/man/plot_peaks.Rd
@@ -22,7 +22,7 @@ strings.}
 
 \item{tick_height}{Height of tick marks at the peaks (a number between 0 and 1).}
 
-\item{gap}{Gap between chromosomes. The default is 1% of the total genome length.}
+\item{gap}{Gap between chromosomes. The default is 1\% of the total genome length.}
 
 \item{lod_labels}{If TRUE, plot LOD scores near the intervals. Uses
 three hidden graphics parameters, \code{label_gap} (distance between

--- a/man/plot_scan1.Rd
+++ b/man/plot_scan1.Rd
@@ -26,7 +26,7 @@ strings.}
 \item{add}{If TRUE, add to current plot (must have same map and
 chromosomes).}
 
-\item{gap}{Gap between chromosomes. The default is 1% of the total genome length.}
+\item{gap}{Gap between chromosomes. The default is 1\% of the total genome length.}
 
 \item{...}{Additional graphics parameters.}
 }

--- a/man/plot_scan1.Rd
+++ b/man/plot_scan1.Rd
@@ -6,10 +6,10 @@
 \title{Plot a genome scan}
 \usage{
 plot_scan1(x, map, lodcolumn = 1, chr = NULL, add = FALSE,
-  gap = 25, ...)
+  gap = NULL, ...)
 
 \method{plot}{scan1}(x, map, lodcolumn = 1, chr = NULL, add = FALSE,
-  gap = 25, ...)
+  gap = NULL, ...)
 }
 \arguments{
 \item{x}{Output of \code{\link[=scan1]{scan1()}}.}
@@ -26,7 +26,7 @@ strings.}
 \item{add}{If TRUE, add to current plot (must have same map and
 chromosomes).}
 
-\item{gap}{Gap between chromosomes.}
+\item{gap}{Gap between chromosomes. The default is 1% of the total genome length.}
 
 \item{...}{Additional graphics parameters.}
 }

--- a/man/plot_snpasso.Rd
+++ b/man/plot_snpasso.Rd
@@ -6,7 +6,7 @@
 \usage{
 plot_snpasso(scan1output, snpinfo, genes = NULL, lodcolumn = 1,
   show_all_snps = TRUE, chr = NULL, add = FALSE, drop_hilit = NA,
-  col_hilit = "violetred", col = "darkslateblue", gap = 25,
+  col_hilit = "violetred", col = "darkslateblue", gap = NULL,
   minlod = 0, ...)
 }
 \arguments{
@@ -56,7 +56,7 @@ chromosomes).}
 
 \item{col}{Color of other points}
 
-\item{gap}{Gap between chromosomes.}
+\item{gap}{Gap between chromosomes. The default is 1% of the total genome length.}
 
 \item{minlod}{Minimum LOD to display. (Mostly for GWAS, in which
 case using \code{minlod=1} will greatly increase the plotting speed,

--- a/man/plot_snpasso.Rd
+++ b/man/plot_snpasso.Rd
@@ -56,7 +56,7 @@ chromosomes).}
 
 \item{col}{Color of other points}
 
-\item{gap}{Gap between chromosomes. The default is 1% of the total genome length.}
+\item{gap}{Gap between chromosomes. The default is 1\% of the total genome length.}
 
 \item{minlod}{Minimum LOD to display. (Mostly for GWAS, in which
 case using \code{minlod=1} will greatly increase the plotting speed,

--- a/man/xpos_scan1.Rd
+++ b/man/xpos_scan1.Rd
@@ -4,7 +4,7 @@
 \alias{xpos_scan1}
 \title{Get x-axis position for genomic location}
 \usage{
-xpos_scan1(map, chr = NULL, gap = 25, thechr, thepos)
+xpos_scan1(map, chr = NULL, gap = NULL, thechr, thepos)
 }
 \arguments{
 \item{map}{A list of vectors of marker positions, as produced by

--- a/tests/testthat/test-xpos_scan1.R
+++ b/tests/testthat/test-xpos_scan1.R
@@ -11,14 +11,29 @@ test_that("xpos_scan1 works", {
     # two chromosomes
     map <- list("1"=c(10, 20, 50),
                 "2"=c(5,  25, 85))
-    expect_equal(xpos_scan1(map, thechr=c("1", "2"), thepos=c(20, 25)),
+    expect_equal(xpos_scan1(map, thechr=c("1", "2"), thepos=c(20, 25), gap=25),
                  c(22.5, 97.5))
-    expect_equal(xpos_scan1(map, thechr="1", thepos=c(15, 40)),
+    expect_equal(xpos_scan1(map, thechr="1", thepos=c(15, 40), gap=25),
                  c(17.5, 42.5))
-    expect_equal(xpos_scan1(map, thechr=c("1", "2"), thepos=10),
+    expect_equal(xpos_scan1(map, thechr=c("1", "2"), thepos=10, gap=25),
                  c(12.5, 82.5))
 
 
+    # two chromosomes, automatic gap
+    expect_equal(xpos_scan1(map, thechr=c("1", "2"), thepos=c(20, 25)),
+                 xpos_scan1(map, thechr=c("1", "2"), thepos=c(20, 25), gap=1.2))
+    expect_equal(xpos_scan1(map, thechr="1", thepos=c(15, 40)),
+                 xpos_scan1(map, thechr="1", thepos=c(15, 40), gap=1.2))
+    expect_equal(xpos_scan1(map, thechr=c("1", "2"), thepos=10),
+                 xpos_scan1(map, thechr=c("1", "2"), thepos=10, gap=1.2))
+    expect_equal(xpos_scan1(map, thechr=c("1", "2"), thepos=c(20, 25)),
+                 c(10.6, 61.8))
+    expect_equal(xpos_scan1(map, thechr="1", thepos=c(15, 40)),
+                 c(5.6, 30.6))
+    expect_equal(xpos_scan1(map, thechr=c("1", "2"), thepos=10),
+                 c(0.6, 46.8))
+
+    # invalid inputs
     expect_error(xpos_scan1(map, thechr=c("1", "2", "2"), thepos=c(5, 10)))
     expect_error(xpos_scan1(map, thechr=c("1", "2"), thepos=c(5, 10, 15)))
     expect_error(xpos_scan1(map, thechr=c("1", "2", "3"), thepos=c(5, 10, 15)))


### PR DESCRIPTION
Change to default gap between chromosomes in `plot_scan1()` and related, to be 1% of the total genome length rather than a fixed 25.

- Implements Issue #90.