### PR TITLE
Fix bug in step probabilities for multi-way RIL by selfing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.19-2
-Date: 2019-02-16
+Version: 0.19-3
+Date: 2019-03-04
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-## qtl2 0.19-2 (2019-02-16)
+## qtl2 0.19-3 (2019-03-04)
 
 ### Bug fixes
+
+- Fix bug in step probabilities for 4-, 8-, and 16-way RIL by selfing.
 
 - Fix bug in `zip_datafiles()` when the files are in a subdirectory.
   (See [Issue #102](https://github.com/rqtl/qtl2/issues/102).)

--- a/src/cross_riself16.cpp
+++ b/src/cross_riself16.cpp
@@ -73,6 +73,7 @@ const double RISELF16::step(const int gen_left, const int gen_right, const doubl
     // equations are from Teuscher and Broman Genetics 175:1267-1274, 2007
     //    doi:10.1534/genetics.106.064063
     //    see equation 1 in right column on page 1269
+    //    (need to multiply by 16 to get conditional probabilities)
     if(gen_left == gen_right)
         return 3.0*log(1.0-rec_frac) - log(1.0 + 2.0 * rec_frac);
 

--- a/src/cross_riself16.cpp
+++ b/src/cross_riself16.cpp
@@ -74,21 +74,21 @@ const double RISELF16::step(const int gen_left, const int gen_right, const doubl
     //    doi:10.1534/genetics.106.064063
     //    see equation 1 in right column on page 1269
     if(gen_left == gen_right)
-        return 3.0*log(1.0-rec_frac) - log(16.0) - log(1.0 + 2.0 * rec_frac);
+        return 3.0*log(1.0-rec_frac) - log(1.0 + 2.0 * rec_frac);
 
     // first get inverted index of cross info
     IntegerVector founder_index = invert_founder_index(cross_info);
 
     // were the two founders crossed to each other at the first generation?
     if(founder_index[gen_left-1] / 2 == founder_index[gen_right-1] / 2) // next to each other
-        return log(rec_frac) + 2.0*log(1.0 - rec_frac) - log(16.0) - log(1.0 + 2.0 * rec_frac);
+        return log(rec_frac) + 2.0*log(1.0 - rec_frac) - log(1.0 + 2.0 * rec_frac);
 
     // were the two founders in the same group of 4?
     if(founder_index[gen_left-1] / 4 == founder_index[gen_right-1] / 4)
-        return log(rec_frac) + log(1.0 - rec_frac) - log(32.0) - log(1.0 + 2.0 * rec_frac);
+        return log(rec_frac) + log(1.0 - rec_frac) - log(2.0) - log(1.0 + 2.0 * rec_frac);
 
     // off the block-diagonal
-    return log(rec_frac) - log(64.0) - log(1.0 + 2.0 * rec_frac);
+    return log(rec_frac) - log(4.0) - log(1.0 + 2.0 * rec_frac);
 
 }
 

--- a/src/cross_riself4.cpp
+++ b/src/cross_riself4.cpp
@@ -71,9 +71,9 @@ const double RISELF4::step(const int gen_left, const int gen_right, const double
     #endif
 
     if(gen_left != gen_right)
-        return log(rec_frac) - log(4.0) - log(1.0 + 2.0*rec_frac);
+        return log(rec_frac) - log(1.0 + 2.0*rec_frac);
     else
-        return log(1.0 - rec_frac) - log(4.0) - log(1.0 + 2.0*rec_frac);
+        return log(1.0 - rec_frac) - log(1.0 + 2.0*rec_frac);
 }
 
 const IntegerVector RISELF4::possible_gen(const bool is_x_chr, const bool is_female,

--- a/src/cross_riself4.cpp
+++ b/src/cross_riself4.cpp
@@ -70,6 +70,10 @@ const double RISELF4::step(const int gen_left, const int gen_right, const double
         throw std::range_error("genotype value not allowed");
     #endif
 
+    // equations are from Broman (2005) Genetics 169:1133-1146
+    //    doi:10.1534/genetics.104.035212
+    //    see equation in right column on page 1135
+    //    (need to multiply by 4 to get conditional probabilities)
     if(gen_left != gen_right)
         return log(rec_frac) - log(1.0 + 2.0*rec_frac);
     else

--- a/src/cross_riself8.cpp
+++ b/src/cross_riself8.cpp
@@ -78,17 +78,17 @@ const double RISELF8::step(const int gen_left, const int gen_right, const double
     //     doi:10.1534/genetics.104.035212
     //     see table 2 on page 1136
     if(gen_left == gen_right)
-        return 2.0*log(1.0-rec_frac) - log(8.0) - log(1.0 + 2.0 * rec_frac);
+        return 2.0*log(1.0-rec_frac) - log(1.0 + 2.0 * rec_frac);
 
     // first get inverted index of cross info
     IntegerVector founder_index = invert_founder_index(cross_info);
 
     // were the two founders crossed to each other directly?
     if(founder_index[gen_left-1] / 2 == founder_index[gen_right-1] / 2) // next to each other
-        return log(rec_frac) + log(1.0 - rec_frac) - log(8.0) - log(1.0 + 2.0 * rec_frac);
+        return log(rec_frac) + log(1.0 - rec_frac) - log(1.0 + 2.0 * rec_frac);
 
     // off the block-diagonal
-    return log(rec_frac) - log(16.0) - log(1.0 + 2.0 * rec_frac);
+    return log(rec_frac) - log(2.0) - log(1.0 + 2.0 * rec_frac);
 }
 
 const IntegerVector RISELF8::possible_gen(const bool is_x_chr, const bool is_female,

--- a/src/cross_riself8.cpp
+++ b/src/cross_riself8.cpp
@@ -73,10 +73,12 @@ const double RISELF8::step(const int gen_left, const int gen_right, const double
     // equations are from Teuscher and Broman Genetics 175:1267-1274, 2007
     //     doi:10.1534/genetics.106.064063
     //     see equation 1 in right column on page 1269
+    //     (need to multiply by 8 to get conditional probabilities)
     //
     // They also appear in Broman Genetics 169:1133-1146, 2005
     //     doi:10.1534/genetics.104.035212
     //     see table 2 on page 1136
+    //     (again, multiply by 8 to get conditional probabilities)
     if(gen_left == gen_right)
         return 2.0*log(1.0-rec_frac) - log(1.0 + 2.0 * rec_frac);
 

--- a/src/cross_risib4.cpp
+++ b/src/cross_risib4.cpp
@@ -83,6 +83,7 @@ const double RISIB4::step(const int gen_left, const int gen_right, const double 
         // equations are from Broman (2005) Genetics 169:1133-1146
         //    doi:10.1534/genetics.104.035212
         //    see top equation in right column on page 1137
+        //    (need to multiply by 4 to get conditional probabilities)
         if(gen_left == gen_right)
             return -log(1.0 + 6.0 * rec_frac);
 
@@ -92,6 +93,7 @@ const double RISIB4::step(const int gen_left, const int gen_right, const double 
         // equations are from Broman (2005) Genetics 169:1133-1146
         //    doi:10.1534/genetics.104.035212
         //    see right column on page 1136
+        //    (need to multiply by 3 to get conditional probabilities)
         if(gen_left == gen_right)
             return - log(1.0 + 4.0 * rec_frac);
 

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -88,6 +88,8 @@ const double RISIB8::step(const int gen_left, const int gen_right, const double 
         // equations are from Broman (2005) Genetics 169:1133-1146
         //    doi:10.1534/genetics.104.035212
         //    see bottom equation in right column on page 1137
+        //    (need to multiply by 8 to get conditional probabilities,
+        //     and note that there was an error in the i != j case)
         if(gen_left == gen_right)
             return log(1.0 - rec_frac) - log(1.0 + 6.0 * rec_frac);
 
@@ -97,6 +99,8 @@ const double RISIB8::step(const int gen_left, const int gen_right, const double 
         // equations are from Broman (2005) Genetics 169:1133-1146
         //    doi:10.1534/genetics.104.035212
         //    see table 4 page 1137
+        //    (need to multiply by the marginal probability, 1/6 or 1/3,
+        //     to get these conditional probabilities)
         if(gen_left == gen_right) {
             if(gen_left == cross_info[2])
                 return - log(1.0 + 4.0 * rec_frac);

--- a/tests/testthat/test-hmmbasic-riself4-8-16.R
+++ b/tests/testthat/test-hmmbasic-riself4-8-16.R
@@ -35,8 +35,8 @@ test_that("riself4-8-16 init work", {
 test_that("riself4 step works", {
 
     for(rf in c(0.01, 0.1, 0.45)) {
-        expected <- matrix(rf/4/(1+2*rf), ncol=4, nrow=4)
-        diag(expected) <- (1-rf)/4/(1+2*rf)
+        expected <- matrix(rf/(1+2*rf), ncol=4, nrow=4)
+        diag(expected) <- (1-rf)/(1+2*rf)
 
         result <- matrix(ncol=4, nrow=4)
         for(i in 1:4) {
@@ -54,12 +54,12 @@ test_that("riself4 step works", {
 test_that("riself8 step works", {
 
     for(rf in c(0.01, 0.1, 0.45)) {
-        expected <- matrix(rf/16/(1+2*rf), ncol=8, nrow=8)
-        diag(expected) <- (1-rf)^2/8/(1+2*rf)
+        expected <- matrix(rf/2/(1+2*rf), ncol=8, nrow=8)
+        diag(expected) <- (1-rf)^2/(1+2*rf)
         block <- list(c(1,2), c(3,4), c(5,6), c(7,8))
         for(i in seq_along(block)) {
             b <- block[[i]]
-            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)/8/(1+2*rf)
+            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)/(1+2*rf)
         }
 
         result <- matrix(ncol=8, nrow=8)
@@ -77,12 +77,12 @@ test_that("riself8 step works", {
     forder_rev <- c(5,4,1,8,3,7,6,2)
 
     for(rf in c(0.01, 0.1, 0.45)) {
-        expected <- matrix(rf/16/(1+2*rf), ncol=8, nrow=8)
-        diag(expected) <- (1-rf)^2/8/(1+2*rf)
+        expected <- matrix(rf/2/(1+2*rf), ncol=8, nrow=8)
+        diag(expected) <- (1-rf)^2/(1+2*rf)
         block <- list(c(1,2), c(3,4), c(5,6), c(7,8))
         for(i in seq_along(block)) {
             b <- block[[i]]
-            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)/8/(1+2*rf)
+            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)/(1+2*rf)
         }
         expected <- expected[forder_rev, forder_rev]
 
@@ -104,14 +104,14 @@ test_that("riself8 step works", {
 test_that("riself16 step works", {
 
     for(rf in c(0.01, 0.1, 0.45)) {
-        expected <- matrix(rf/64/(1+2*rf), ncol=16, nrow=16)
+        expected <- matrix(rf/4/(1+2*rf), ncol=16, nrow=16)
         expected[1:4,1:4] <- expected[5:8,5:8] <-
-            expected[9:12,9:12] <- expected[13:16,13:16] <- rf*(1-rf)/32/(1+2*rf)
-        diag(expected) <- (1-rf)^3/16/(1+2*rf)
+            expected[9:12,9:12] <- expected[13:16,13:16] <- rf*(1-rf)/2/(1+2*rf)
+        diag(expected) <- (1-rf)^3/(1+2*rf)
         block <- list(c(1,2), c(3,4), c(5,6), c(7,8),c(9,10),c(11,12),c(13,14),c(15,16))
         for(i in seq_along(block)) {
             b <- block[[i]]
-            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)^2/16/(1+2*rf)
+            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)^2/(1+2*rf)
         }
 
         result <- matrix(ncol=16, nrow=16)
@@ -128,14 +128,14 @@ test_that("riself16 step works", {
     forder <- c(12, 5, 15, 13, 14, 1, 2, 3, 9, 10, 6, 11, 8, 4, 16, 7)
     forder_rev <- c(6,7,8,14,2,11,16,13,9,10,12,1,4,5,3,15)
     for(rf in c(0.01, 0.1, 0.45)) {
-        expected <- matrix(rf/64/(1+2*rf), ncol=16, nrow=16)
+        expected <- matrix(rf/4/(1+2*rf), ncol=16, nrow=16)
         expected[1:4,1:4] <- expected[5:8,5:8] <-
-            expected[9:12,9:12] <- expected[13:16,13:16] <- rf*(1-rf)/32/(1+2*rf)
-        diag(expected) <- (1-rf)^3/16/(1+2*rf)
+            expected[9:12,9:12] <- expected[13:16,13:16] <- rf*(1-rf)/2/(1+2*rf)
+        diag(expected) <- (1-rf)^3/(1+2*rf)
         block <- list(c(1,2), c(3,4), c(5,6), c(7,8),c(9,10),c(11,12),c(13,14),c(15,16))
         for(i in seq_along(block)) {
             b <- block[[i]]
-            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)^2/16/(1+2*rf)
+            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)^2/(1+2*rf)
         }
         expected <- expected[forder_rev, forder_rev]
 


### PR DESCRIPTION
Fix a bug in the step probabilities for 4-, 8-, and 16-way RIL by selfing (cross types `riself4`, `riself8`, and `riself16`). I was calculating joint probabilities but needed conditional probabilities.