### PR TITLE
Fix issue #89 re keep_all_snps=FALSE in scan1snps()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Description: R/qtl2 provides a set of tools to perform quantitative
     high-dimensional data and complex cross designs. This package is
     designed to make it easy to install and load multiple R/qtl2
     packages in a single step.
+    Broman et al. (2018) <doi:10.1534/genetics.118.301595>.
 Author: Karl W Broman <broman@wisc.edu>
 Maintainer: Karl W Broman <broman@wisc.edu>
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.19-4
-Date: 2019-03-05
+Version: 0.19-5
+Date: 2019-03-08
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2 0.19-3 (2019-03-05)
+## qtl2 0.19-5 (2019-03-08)
 
 ### Minor changes
 
@@ -6,6 +6,11 @@
   annotations. Some of the field names have changed.
 
 ### Bug fixes
+
+- Fix bug in `scan1snps()` re `keep_all_snps=FALSE`. It wasn't
+  subsetting to the indexed SNPs properly. Added an internal function
+  `reduce_to_indexed_snps()`.
+  (See [Issue #89](https://github.com/rqtl/qtl2/issues/89).)
 
 - Fix bug in step probabilities for 4-, 8-, and 16-way RIL by selfing.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,8 @@
 ### Bug fixes
 
 - Fix bug in `scan1snps()` re `keep_all_snps=FALSE`. It wasn't
-  subsetting to the indexed SNPs properly. Added an internal function
-  `reduce_to_indexed_snps()`.
+  subsetting to the index SNPs properly. Added an internal function
+  `reduce_to_index_snps()`.
   (See [Issue #89](https://github.com/rqtl/qtl2/issues/89).)
 
 - Fix bug in step probabilities for 4-, 8-, and 16-way RIL by selfing.

--- a/R/reduce_to_index_snps.R
+++ b/R/reduce_to_index_snps.R
@@ -1,5 +1,5 @@
 # reduce snpinfo to the indexed snps
-reduce_to_indexed_snps <- function(snpinfo)
+reduce_to_index_snps <- function(snpinfo)
 {
     if(length(unique(snpinfo$chr)) > 1) { # more than one chromosome
         # rows for each chromosome
@@ -8,7 +8,7 @@ reduce_to_indexed_snps <- function(snpinfo)
         # apply this function to one chromosome at a time
         result <- vector("list", length(rows_spl))
         for(chr in seq_along(rows_spl)) {
-            result[[chr]] <- reduce_to_indexed_snps(snpinfo[rows_spl[[chr]],,drop=FALSE])
+            result[[chr]] <- reduce_to_index_snps(snpinfo[rows_spl[[chr]],,drop=FALSE])
         }
 
         # re-combine by rows

--- a/R/reduce_to_indexed_snps.R
+++ b/R/reduce_to_indexed_snps.R
@@ -1,0 +1,27 @@
+# reduce snpinfo to the indexed snps
+reduce_to_indexed_snps <- function(snpinfo)
+{
+    if(length(unique(snpinfo$chr)) > 1) { # more than one chromosome
+        # rows for each chromosome
+        rows_spl <- split(1:nrow(snpinfo), factor(snpinfo$chr, unique(snpinfo$chr)))
+
+        # apply this function to one chromosome at a time
+        result <- vector("list", length(rows_spl))
+        for(chr in seq_along(rows_spl)) {
+            result[[chr]] <- reduce_to_indexed_snps(snpinfo[rows_spl[[chr]],,drop=FALSE])
+        }
+
+        # re-combine by rows
+        return( do.call("rbind", result) )
+    }
+
+    # now working with just one chromosome
+    if(any(snpinfo$index < 1 | snpinfo$index > nrow(snpinfo))) {
+        stop("index seems messed up for chromosome ", snpinfo$chr[1])
+    }
+
+    result <- snpinfo[unique(snpinfo$index), , drop=FALSE]
+    result$index <- seq_len(nrow(result))
+
+    result
+}

--- a/R/scan1snps.R
+++ b/R/scan1snps.R
@@ -278,7 +278,7 @@ scan1snps_snpinfo <-
                  weights=weights, reml=reml, model=model, ...)
 
     if(!keep_all_snps) {
-        snpinfo <- reduce_to_indexed_snps(snpinfo)
+        snpinfo <- reduce_to_index_snps(snpinfo)
     }
 
     # return list with lod scores + indexed snpinfo

--- a/R/scan1snps.R
+++ b/R/scan1snps.R
@@ -278,8 +278,7 @@ scan1snps_snpinfo <-
                  weights=weights, reml=reml, model=model, ...)
 
     if(!keep_all_snps) {
-        snpinfo <- snpinfo[unique(snpinfo$index),,drop=FALSE]
-        snpinfo$index <- seq_len(nrow(snpinfo))
+        snpinfo <- reduce_to_indexed_snps(snpinfo)
     }
 
     # return list with lod scores + indexed snpinfo

--- a/tests/testthat/test-reduce_to_indexed_snps.R
+++ b/tests/testthat/test-reduce_to_indexed_snps.R
@@ -1,0 +1,48 @@
+context("reduce to indexed snps")
+
+test_that("reduce_to_index_snps works", {
+
+    # founder genotypes for a set of SNPs
+    snpgeno <- rbind(m1=c(3,1,1,3,1,1,1,1),
+                     m2=c(1,3,1,3,1,3,1,3),
+                     m3=c(1,1,1,1,3,3,3,3),
+                     m4=c(1,3,1,3,1,3,1,3),
+                     m5=c(1,1,1,3,1,3,1,1),
+                     m6=c(1,1,3,1,1,1,3,1))
+    sdp <- calc_sdp(snpgeno)
+    snpinfo <- data.frame(chr=c("19", "19", "X", "X", "19", "X"),
+                          pos=c(40.36, 40.53, 110.91, 111.21, 56.480843, 56.480843),
+                          sdp=sdp,
+                          snp=c("m1", "m2", "m3", "m4", "m5", "m6"), stringsAsFactors=FALSE)
+
+    snpinfo <- cbind(snpinfo[c(1,2,5,6,3,4),],
+                     index=c(1:3, 1:3),
+                     interval=c(91,91,132,112,237,237),
+                     on_map=c(FALSE, FALSE, TRUE, FALSE, FALSE, FALSE))
+
+    expect_equal(reduce_to_indexed_snps(snpinfo), snpinfo)
+    expect_equal(reduce_to_indexed_snps(snpinfo[snpinfo$chr==19,]), snpinfo[snpinfo$chr==19,])
+    expect_equal(reduce_to_indexed_snps(snpinfo[snpinfo$chr=="X",]), snpinfo[snpinfo$chr=="X",])
+
+    # repeat with some redundant snps
+    snpinfo_extra <- data.frame(chr=c("19", "19", "X", "X"),
+                                pos=c(40.45, 40.37, 56.3, 110.83),
+                                sdp=c(170, 9, 68, 170),
+                                snp=c("m7", "m8", "m9", "m10"),
+                                stringsAsFactors=FALSE)
+    rownames(snpinfo_extra) <- snpinfo_extra$snp
+    snpinfo_extra <- rbind(snpinfo[,1:4], snpinfo_extra)
+
+    snpinfo_extra <- cbind(snpinfo_extra[c(1,8,7,2,3,  9,4,10,5,6),],
+                      index=c(1,1,3,3,5,  1,1,3,4,3),
+                      interval=c(91,91,91,91,132,  112,112,237,237,237),
+                      on_map=c(FALSE,FALSE,FALSE,FALSE,TRUE,   FALSE,FALSE,FALSE,FALSE,FALSE))
+
+    expected <- snpinfo_extra[c(1,3,5,6,8,9),]
+    expected$index <- c(1,2,3,1,2,3)
+
+    expect_equal(reduce_to_indexed_snps(snpinfo_extra), expected)
+    expect_equal(reduce_to_indexed_snps(snpinfo_extra[snpinfo_extra$chr==19,]), expected[expected$chr==19,])
+    expect_equal(reduce_to_indexed_snps(snpinfo_extra[snpinfo_extra$chr=="X",]), expected[expected$chr=="X",])
+
+})

--- a/tests/testthat/test-reduce_to_indexed_snps.R
+++ b/tests/testthat/test-reduce_to_indexed_snps.R
@@ -1,4 +1,4 @@
-context("reduce to indexed snps")
+context("reduce to index snps")
 
 test_that("reduce_to_index_snps works", {
 
@@ -20,9 +20,9 @@ test_that("reduce_to_index_snps works", {
                      interval=c(91,91,132,112,237,237),
                      on_map=c(FALSE, FALSE, TRUE, FALSE, FALSE, FALSE))
 
-    expect_equal(reduce_to_indexed_snps(snpinfo), snpinfo)
-    expect_equal(reduce_to_indexed_snps(snpinfo[snpinfo$chr==19,]), snpinfo[snpinfo$chr==19,])
-    expect_equal(reduce_to_indexed_snps(snpinfo[snpinfo$chr=="X",]), snpinfo[snpinfo$chr=="X",])
+    expect_equal(reduce_to_index_snps(snpinfo), snpinfo)
+    expect_equal(reduce_to_index_snps(snpinfo[snpinfo$chr==19,]), snpinfo[snpinfo$chr==19,])
+    expect_equal(reduce_to_index_snps(snpinfo[snpinfo$chr=="X",]), snpinfo[snpinfo$chr=="X",])
 
     # repeat with some redundant snps
     snpinfo_extra <- data.frame(chr=c("19", "19", "X", "X"),
@@ -41,8 +41,8 @@ test_that("reduce_to_index_snps works", {
     expected <- snpinfo_extra[c(1,3,5,6,8,9),]
     expected$index <- c(1,2,3,1,2,3)
 
-    expect_equal(reduce_to_indexed_snps(snpinfo_extra), expected)
-    expect_equal(reduce_to_indexed_snps(snpinfo_extra[snpinfo_extra$chr==19,]), expected[expected$chr==19,])
-    expect_equal(reduce_to_indexed_snps(snpinfo_extra[snpinfo_extra$chr=="X",]), expected[expected$chr=="X",])
+    expect_equal(reduce_to_index_snps(snpinfo_extra), expected)
+    expect_equal(reduce_to_index_snps(snpinfo_extra[snpinfo_extra$chr==19,]), expected[expected$chr==19,])
+    expect_equal(reduce_to_index_snps(snpinfo_extra[snpinfo_extra$chr=="X",]), expected[expected$chr=="X",])
 
 })


### PR DESCRIPTION
- Added `reduce_to_index_snps()` for reducing snpinfo tables to just the indexed SNPs
- Use this in `scan1snps()` versus the crap I was trying to do within `scan1snps()`.