### PR TITLE
Fix bug in genoprob_to_snpprob() when including cross2 object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.19-10
-Date: 2019-05-04
+Version: 0.19-11
+Date: 2019-05-21
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2 0.19-10 (2019-05-03)
+## qtl2 0.19-11 (2019-05-21)
 
 ### Major changes
 
@@ -21,6 +21,9 @@
 - Use Markdown for function documentation, throughout
 
 ### Bug fixes
+
+- In `genoprob_to_snpprob()` when a cross object is provided, make
+  sure the genotype probabilities get subset to the cross markers.
 
 - Fixed bug in `scan1snps()` re `keep_all_snps=FALSE`. It wasn't
   subsetting to the index SNPs properly. Added an internal function

--- a/R/genoprob_to_snpprob.R
+++ b/R/genoprob_to_snpprob.R
@@ -27,7 +27,8 @@
 #' Alternatively, `snpinfo` can be a cross object for a multi-parent
 #' population with founder genotypes, in which case the SNP
 #' information for all markers with complete founder genotype data is
-#' calculated and then used.
+#' calculated and then used. But, in this case, the genotype
+#' probabilities must be at the markers in the cross.
 #'
 #' @return An object like the `genoprobs` input, but with imputed
 #' genotype probabilities at the selected SNPs indicated in

--- a/R/snpprob_from_cross.R
+++ b/R/snpprob_from_cross.R
@@ -14,7 +14,7 @@ snpprob_from_cross <-
 
     # subset to common chr
     chr_pr <- names(genoprobs)
-    chr_cross <- chrnames(cross)
+    chr_cross <- chr_names(cross)
     chr <- chr_pr[chr_pr %in% chr_cross]
     cross <- cross[,chr]
     genoprobs <- genoprobs[,chr]


### PR DESCRIPTION
 - If genoprobs didn't include *all* of the cross2 markers, you'd get a cryptic error.
 - Fixes Issue #113.