### PR TITLE
fit1 with blup; pull_genoprobpos() with position

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.21-3
-Date: 2019-07-16
+Version: 0.21-4
+Date: 2019-07-17
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: R/qtl2 provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
-## qtl2 0.21-3 (2019-07-16)
+## qtl2 0.21-3 (2019-07-17)
 
 ### Major changes
 
 - Added some functions for diagnostics: `recode_snps()`,
   `calc_raw_het()`, `calc_raw_geno_freq()`, `calc_raw_maf()`, and
   `calc_raw_founder_maf()`.
+
+- Added argument `blup` to `fit1()`, for getting BLUPs for a single
+  fixed QTL position. At present, just gives estimates and
+  coefficients by calling `scan1blup()` with a single position.
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2 0.21-3 (2019-07-17)
+## qtl2 0.21-4 (2019-07-17)
 
 ### Major changes
 
@@ -16,7 +16,7 @@
 
 ### Bug fixes
 
-- Fix typo in help for `scan1()` and related functions.
+- Fixed typo in help for `scan1()` and related functions.
 
 
 ## qtl2 0.20 (2019-06-03)
@@ -29,7 +29,7 @@
   `scan1blup()`). The previous behavior can be obtained with the
   argument `zerosum=FALSE`.
 
-- Add function `create_snpinfo()` for creating a SNP information table
+- Added function `create_snpinfo()` for creating a SNP information table
   from a cross2 object, for use with `scan1snps()`.
 
 ### Minor changes
@@ -40,7 +40,7 @@
 - In `check_cross2()`, added a test for alleles being a vector of
   character strings.
 
-- Fix some tests for R 3.6, due to change in random number generation.
+- Fixed some tests for R 3.6, due to change in random number generation.
 
 - Use Markdown for function documentation, throughout
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
 
 - Fixed typo in help for `scan1()` and related functions.
 
+- `genoprob_to_snpprob()` was giving an error if you gave a cross2
+  object in place of a snpinfo table and it had monomorphic markers.
+
 
 ## qtl2 0.20 (2019-06-03)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
   fixed QTL position. At present, just gives estimates and
   coefficients by calling `scan1blup()` with a single position.
 
+- `pull_genoprobpos()` can now take either a marker name (as before) or
+  a set of map, chromosome, and position (from which it uses
+  `find_marker()` to get the marker name).
+
 ### Bug fixes
 
 - Fix typo in help for `scan1()` and related functions.

--- a/R/pull_genoprobpos.R
+++ b/R/pull_genoprobpos.R
@@ -5,10 +5,19 @@
 #'
 #' @param genoprobs Genotype probabilities as calculated by
 #' [calc_genoprob()].
+#' @param map A map object: a list (corresponding to chromosomes) of
+#'     vectors of marker positions. Can also be a snpinfo object (data
+#'     frame with columns `chr` and `pos`; marker names taken from
+#'     column `snp` or if that doesn't exist from the row names)
+#' @param chr A chromosome ID
+#' @param pos A numeric position
 #' @param marker A single character string with the name of the
 #' position to pull out.
 #'
 #' @return A matrix of genotype probabilities for the specified position.
+#'
+#' @details Provide either a marker/pseudomarker name (with the argument `marker`)
+#' or all of `map`, `chr`, and `pos`.
 #'
 #' @seealso [find_marker()], [fit1()], [pull_genoprobint()]
 #'
@@ -21,11 +30,27 @@
 #' pmar <- find_marker(gmap, 8, 40)
 #' pr_8_40 <- pull_genoprobpos(pr, pmar)
 #'
+#' pr_8_40_alt <- pull_genoprobpos(pr, gmap, 8, 40)
+#'
 #' @export
 pull_genoprobpos <-
-    function(genoprobs, marker)
+    function(genoprobs, map=NULL, chr=NULL, pos=NULL, marker=NULL)
 {
     if(is.null(genoprobs)) stop("genoprobs is NULL")
+
+    if(is.character(map) && is.null(chr) && is.null(pos) && is.null(marker)) {
+        # treat this as map -> marker
+        marker <- map
+        map <- NULL
+    }
+
+    if(!is.null(marker) && (!is.null(map) || !is.null(chr) || !is.null(pos))) {
+        warning("Provide either {map,chr,pos} or marker, not both; using marker")
+    }
+    if(is.null(marker)) {
+        marker <- find_marker(map, chr, pos)
+    }
+
     if(length(marker) == 0) stop("marker has length 0")
     if(length(marker) > 1) {
         marker <- marker[1]

--- a/R/snpprob_from_cross.R
+++ b/R/snpprob_from_cross.R
@@ -9,8 +9,10 @@ snpprob_from_cross <-
         stop("cross doesn't contain founder_geno")
 
     ### calculate snp info from cross
-    # drop markers that are missing any founder genotypes
-    cross <- drop_markers(cross, unlist(lapply(cross$founder_geno, function(a) colnames(a)[colSums(a==0)>0])))
+    # drop markers that are missing any founder genotypes or that are monomorphic
+    fg <- do.call("cbind", cross$founder_geno)
+    mar2drop <- colnames(fg)[colSums(fg != 1 & fg != 3) > 0 | colSums(fg==1)==0 | colSums(fg==3)==0]
+    cross <- drop_markers(cross, mar2drop)
 
     # subset to common chr
     chr_pr <- names(genoprobs)

--- a/man/fit1.Rd
+++ b/man/fit1.Rd
@@ -7,7 +7,7 @@
 fit1(genoprobs, pheno, kinship = NULL, addcovar = NULL,
   nullcovar = NULL, intcovar = NULL, weights = NULL,
   contrasts = NULL, model = c("normal", "binary"), zerosum = TRUE,
-  se = TRUE, hsq = NULL, reml = TRUE, ...)
+  se = TRUE, hsq = NULL, reml = TRUE, blup = FALSE, ...)
 }
 \arguments{
 \item{genoprobs}{A matrix of genotype probabilities, individuals x genotypes}
@@ -55,6 +55,8 @@ the mean. Ignored if \code{contrasts} is provided.}
 \item{reml}{If \code{kinship} provided: if \code{reml=TRUE}, use
 REML; otherwise maximum likelihood.}
 
+\item{blup}{If TRUE, fit a model with QTL effects being random, as in \code{\link[=scan1blup]{scan1blup()}}.}
+
 \item{...}{Additional control parameters; see Details;}
 }
 \value{
@@ -65,6 +67,7 @@ A list containing
 \item \code{lod} - The overall lod score.
 \item \code{ind_lod} - Vector of individual contributions to the LOD score.
 \item \code{fitted}  - Fitted values.
+If \code{blup==TRUE}, only \code{coef} and \code{SE} are included at present.
 }
 }
 \description{

--- a/man/pull_genoprobpos.Rd
+++ b/man/pull_genoprobpos.Rd
@@ -4,11 +4,21 @@
 \alias{pull_genoprobpos}
 \title{Pull genotype probabilities for a particular position}
 \usage{
-pull_genoprobpos(genoprobs, marker)
+pull_genoprobpos(genoprobs, map = NULL, chr = NULL, pos = NULL,
+  marker = NULL)
 }
 \arguments{
 \item{genoprobs}{Genotype probabilities as calculated by
 \code{\link[=calc_genoprob]{calc_genoprob()}}.}
+
+\item{map}{A map object: a list (corresponding to chromosomes) of
+vectors of marker positions. Can also be a snpinfo object (data
+frame with columns \code{chr} and \code{pos}; marker names taken from
+column \code{snp} or if that doesn't exist from the row names)}
+
+\item{chr}{A chromosome ID}
+
+\item{pos}{A numeric position}
 
 \item{marker}{A single character string with the name of the
 position to pull out.}
@@ -20,6 +30,10 @@ A matrix of genotype probabilities for the specified position.
 Pull out the genotype probabilities for a particular position (by
 name)
 }
+\details{
+Provide either a marker/pseudomarker name (with the argument \code{marker})
+or all of \code{map}, \code{chr}, and \code{pos}.
+}
 \examples{
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
 \dontshow{iron <- iron[,"8"]}
@@ -28,6 +42,8 @@ pr <- calc_genoprob(iron, gmap, error_prob=0.002)
 
 pmar <- find_marker(gmap, 8, 40)
 pr_8_40 <- pull_genoprobpos(pr, pmar)
+
+pr_8_40_alt <- pull_genoprobpos(pr, gmap, 8, 40)
 
 }
 \seealso{

--- a/tests/testthat/test-fit1.R
+++ b/tests/testthat/test-fit1.R
@@ -509,3 +509,29 @@ test_that("fit1 handles contrasts properly in an intercross", {
     expect_equal(attr(ests_c13, "SE")["D13M254",], out_fit1b$SE)
 
 })
+
+test_that("fit1 works with blup=TRUE", {
+
+    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+    map <- insert_pseudomarkers(iron$gmap, step=1)
+    probs <- calc_genoprob(iron, map, error_prob=0.002)
+    Xcovar <- get_x_covar(iron)
+    kinship <- calc_kinship(probs, "loco")
+
+    # pull out a position
+    marker <- find_marker(map, "2", 56.8)
+    pr_pos <- pull_genoprobpos(probs, marker=marker)
+
+    # reduce the probs to a few positions
+    probs[[2]] <- probs[[2]][,, which(dimnames(probs[[2]])[[3]]==marker) + -2:1]
+
+    out_scan1blup <- scan1blup(probs[,2], iron$pheno[,1], kinship[[2]])
+    out_scan1blup_nok <- scan1blup(probs[,2], iron$pheno[,1])
+
+    expect_equal( fit1(pr_pos, iron$pheno[,1], kinship[[2]], blup=TRUE, se=FALSE)$coef,
+                 out_scan1blup[marker,] )
+
+    expect_equal( fit1(pr_pos, iron$pheno[,1], blup=TRUE, se=FALSE)$coef,
+                 out_scan1blup_nok[marker,] )
+
+})

--- a/tests/testthat/test-pull_genoprobpos.R
+++ b/tests/testthat/test-pull_genoprobpos.R
@@ -10,6 +10,7 @@ test_that("pull_genoprobpos works", {
     pmar <- find_marker(gmap, 8, 40)
     pr_8_40 <- pull_genoprobpos(pr, pmar)
     expect_equal(pr_8_40, pr[["8"]][,,"c8.loc40"])
+    expect_equal(pr_8_40, pull_genoprobpos(pr, marker=pmar))
 
     expect_equal(pull_genoprobpos(pr["275",], pmar),
                  pr_8_40["275",,drop=FALSE])
@@ -17,5 +18,9 @@ test_that("pull_genoprobpos works", {
     expect_warning(pull_genoprobpos(pr, c("c8.loc40", find_marker(gmap, 8, 70))))
 
     expect_error(pull_genoprobpos(pr, "karl"))
+
+
+    # same result if you provide gmap, chr, pos
+    expect_equal(pr_8_40, pull_genoprobpos(pr, gmap, 8, 40))
 
 })


### PR DESCRIPTION
- Implements Issue #87 re `fit1()` with blup
- Implements Issue #124 re `pull_genoprobpos()` with position rather than marker name
- Also a fix of Issue #123 re `genoprob_to_snpprob()` when input cross2 object has monomorphic markers.