### PR TITLE
Revise reduce_markers(); fix bug in fit1()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.23-1
-Date: 2020-07-10
+Version: 0.23-2
+Date: 2020-09-01
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: Provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.22-11
-Date: 2020-07-09
+Version: 0.23-1
+Date: 2020-07-10
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: Provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## qtl2 0.23-1 (2020-07-10)
+
+Minor changes
+
+- Revised `reduce_markers()` so that it can handle the case of _many_
+  markers, by working with them in smaller batches.
+
+
+
 ## qtl2 0.22-11 (2020-07-09)
 
 ### Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,21 @@
-## qtl2 0.23-1 (2020-07-10)
+## qtl2 0.23-2 (2020-09-01)
 
-Minor changes
+### Minor changes
 
 - Revised `reduce_markers()` so that it can handle the case of _many_
   markers, by working with them in smaller batches.
 
+- `fit1()` now returns both fitted values and residuals.
+
+### Bug fixes
+
+- Fixed [Issue #172](https://github.com/rqtl/qtl2/issues/172), where
+  `fit1()` gave incorrect fitted values when `kinship` is provided,
+  because they weren't "rotated back".
+
+- `fit1()` no longer provides individual LOD scores (`ind_lod`) when
+  `kinship` is used, as with the linear mixed model, the LOD score is
+  not simply the sum of individual contributions.
 
 
 ## qtl2 0.22-11 (2020-07-09)

--- a/R/fit1.R
+++ b/R/fit1.R
@@ -42,8 +42,9 @@
 #' * `coef` - Vector of estimated coefficients.
 #' * `SE` - Vector of estimated standard errors (included if `se=TRUE`).
 #' * `lod` - The overall lod score.
-#' * `ind_lod` - Vector of individual contributions to the LOD score.
+#' * `ind_lod` - Vector of individual contributions to the LOD score (not provided if `kinship` is used).
 #' * `fitted`  - Fitted values.
+#' * `resid`  - Residuals.
 #' If `blup==TRUE`, only `coef` and `SE` are included at present.
 #'
 #' @details For each of the inputs, the row names are used as
@@ -286,7 +287,8 @@ fit1 <-
         ind_lod <- 0.5*(fit0$resid^2/sigsq0 - fitA$resid^2/sigsqA + log(sigsq0) - log(sigsqA))/log(10)
         names(ind_lod) <- names(pheno)
 
-        fitted <- pheno - fitA$resid
+        fitted <- setNames(fitA$fitted, names(pheno))
+        resid <- pheno - fitted
     }
     else { # binary phenotype
         # null fit
@@ -319,6 +321,7 @@ fit1 <-
         ind_lod <- ind_lodA - ind_lod0
 
         fitted <- stats::setNames(pA, names(pheno))
+        resid <- pheno - fitted
     }
 
     # names of coefficients
@@ -343,9 +346,9 @@ fit1 <-
         return(list(lod=lod, ind_lod=ind_lod,
                     coef=stats::setNames(fitA$coef, coef_names),
                     SE=stats::setNames(fitA$SE, coef_names),
-                    fitted=fitted))
+                    fitted=fitted, resid=resid))
     else
         return(list(lod=lod, ind_lod=ind_lod,
                     coef=stats::setNames(fitA$coef, coef_names),
-                    fitted=fitted))
+                    fitted=fitted, resid=resid))
 }

--- a/R/fit1_pg.R
+++ b/R/fit1_pg.R
@@ -148,19 +148,12 @@ fit1_pg <-
     n <- length(pheno)
     lod <- (n/2)*log10(fit0$rss/fitA$rss)
 
-    # residual SDs using 1/n
-    sigsq0 <- fit0$sigma^2/n*fit0$df
-    sigsqA <- fitA$sigma^2/n*fitA$df
-
-    # individual contributions to the lod score
-    ind_lod <- 0.5*(fit0$resid^2/sigsq0 - fitA$resid^2/sigsqA + log(sigsq0) - log(sigsqA))/log(10)
-    names(ind_lod) <- names(pheno)
-
     # names of coefficients
     coef_names <- scan1coef_names(genoprobs, addcovar, intcovar)
 
     # fitted values
-    fitted <- pheno - fitA$resid
+    fitted <- setNames(fitA$fitted, names(pheno))
+    resid <- pheno - fitted
 
     # center the QTL effects at zero and add an intercept
     if(zerosum && is.null(contrasts)) {
@@ -177,14 +170,13 @@ fit1_pg <-
         }
     }
 
-
     if(se) # results include standard errors
-        return(list(lod=lod, ind_lod=ind_lod,
+        return(list(lod=lod,
                     coef=stats::setNames(fitA$coef, coef_names),
                     SE=stats::setNames(fitA$SE, coef_names),
-                    fitted=fitted))
+                    fitted=fitted, resid=resid))
     else
-        return(list(lod=lod, ind_lod=ind_lod,
+        return(list(lod=lod,
                     coef=stats::setNames(fitA$coef, coef_names),
-                    fitted=fitted))
+                    fitted=fitted, resid=resid))
 }

--- a/man/fit1.Rd
+++ b/man/fit1.Rd
@@ -78,8 +78,9 @@ A list containing
 \item \code{coef} - Vector of estimated coefficients.
 \item \code{SE} - Vector of estimated standard errors (included if \code{se=TRUE}).
 \item \code{lod} - The overall lod score.
-\item \code{ind_lod} - Vector of individual contributions to the LOD score.
+\item \code{ind_lod} - Vector of individual contributions to the LOD score (not provided if \code{kinship} is used).
 \item \code{fitted}  - Fitted values.
+\item \code{resid}  - Residuals.
 If \code{blup==TRUE}, only \code{coef} and \code{SE} are included at present.
 }
 }

--- a/man/reduce_markers.Rd
+++ b/man/reduce_markers.Rd
@@ -4,7 +4,14 @@
 \alias{reduce_markers}
 \title{Reduce markers to a subset of more-evenly-spaced ones}
 \usage{
-reduce_markers(map, min_distance = 1, weights = NULL)
+reduce_markers(
+  map,
+  min_distance = 1,
+  weights = NULL,
+  max_batch = 10000,
+  batch_distance_mult = 1,
+  cores = 1
+)
 }
 \arguments{
 \item{map}{A list with each component being a vector with the
@@ -14,6 +21,16 @@ marker positions for a chromosome.}
 
 \item{weights}{A (optional) list of weights on the markers; same
 size as \code{map}.}
+
+\item{max_batch}{Maximum number of markers to consider in a batch}
+
+\item{batch_distance_mult}{If working with batches of markers,
+reduce \code{min_distance} by this multiple.}
+
+\item{cores}{Number of CPU cores to use, for parallel calculations.
+(If \code{0}, use \code{\link[parallel:detectCores]{parallel::detectCores()}}.)
+Alternatively, this can be links to a set of cluster sockets, as
+produced by \code{\link[parallel:makeCluster]{parallel::makeCluster()}}.}
 }
 \value{
 A list like the input \code{map}, but with the selected
@@ -28,6 +45,13 @@ Uses a dynamic programming algorithm to find, for each
 chromosome, the subset of markers for with max(\code{weights}) is
 maximal, subject to the constraint that no two adjacent markers may
 be separated by more than \code{min_distance}.
+
+The computation time for the algorithm grows with like the square
+of the number of markers, like 1 sec for 10k markers
+but 30 sec for 50k markers. If the number of markers on a chromosome
+is greater than \code{max_batch}, the markers are split into batches and
+the algorithm applied to each batch with min_distance smaller by a
+factor \code{min_distance_mult}, and then merged together for one last pass.
 }
 \examples{
 # read data

--- a/src/fit1_pg.cpp
+++ b/src/fit1_pg.cpp
@@ -10,7 +10,7 @@ using namespace Rcpp;
 
 // fit single-QTL model at a single position
 //
-// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// genoprobs = matrix of genotype probabilities (individuals x genotypes)
 // pheno     = vector of numeric phenotypes (individuals x 1)
 //             (no missing data allowed)
 // addcovar  = additive covariates (can be null)
@@ -62,13 +62,21 @@ List fit1_pg_addcovar(const NumericMatrix& genoprobs,
     X = weighted_matrix(X, weights);
 
     // do regression
-    return fit_linreg(X, pheno_rev, se, tol);
+    List result = fit_linreg(X, pheno_rev, se, tol);
+
+    // fix the fitted values (leave the residuals as they are)
+    NumericVector fitted = result["fitted"];
+    NumericVector fitted_rev = matrix_x_vector(transpose(eigenvec), fitted/weights);
+
+    result["fitted"] = fitted_rev;
+
+    return result;
 }
 
 
 // fit single-QTL model at a single position
 //
-// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// genoprobs = matrix of genotype probabilities (individuals x genotypes)
 // pheno     = vector of numeric phenotypes (individuals x 1)
 //             (no missing data allowed)
 // addcovar  = additive covariates (can be null)
@@ -113,5 +121,13 @@ List fit1_pg_intcovar(const NumericMatrix& genoprobs,
     X = weighted_matrix(X, weights);
 
     // do regression
-    return fit_linreg(X, pheno_rev, se, tol);
+    List result = fit_linreg(X, pheno_rev, se, tol);
+
+    // fix the fitted values (leave the residuals as they are)
+    NumericVector fitted = result["fitted"];
+    NumericVector fitted_rev = matrix_x_vector(transpose(eigenvec), fitted/weights);
+
+    result["fitted"] = fitted_rev;
+
+    return result;
 }


### PR DESCRIPTION
- Revise `reduce_markers()` so that it can handle _many_ markers (by splitting into windows)
- Fix bug in `fit1()` regarding the calculation of fitted values when `kinship` is provided, fixing Issue #172. 
- `fit1()` no longer provides `ind_lod` in the output when `kinship` is provided, since the LOD score is not the sum of individual contributions, in this case.
- `fit1()` now includes residuals in the output (as `resid`), as well as the fitted values (`fitted`)