### PR TITLE
Fix a bunch of small problems

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,5 +5,5 @@ Makefile$
 ^inst/scripts/.+\.tbi$
 ^inst/scripts/.+\.sqlite$
 ^\.RData$
-^inst/scripts/\.RData$
+/\.RData$
 ^\.github$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2
-Version: 0.23-10
-Date: 2020-12-03
+Version: 0.23-11
+Date: 2020-12-08
 Title: Quantitative Trait Locus Mapping in Experimental Crosses
 Description: Provides a set of tools to perform quantitative
     trait locus (QTL) analysis in experimental crosses. It is a

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,9 @@
 - Fix Issue #157, to have `calc_genoprob()` give a better error
   message about missing genetic map.
 
+- Fix Issue #178, to have `read_cross2()` give a warning not an error
+  if incorrect number of alleles.
+
 
 ## qtl2 0.22-11 (2020-07-09)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,8 @@
 - Fix Issue #178, to have `read_cross2()` give a warning not an error
   if incorrect number of alleles.
 
+- Fix Issue #180 re `scan1()` error if phenotypes' rownames have rownames.
+
 
 ## qtl2 0.22-11 (2020-07-09)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,9 @@
 - Fix Issue #135, so `plot_scan1()` can take vector input (which is
   then converted to a single-column matrix).
 
+- Fix Issue #157, to have `calc_genoprob()` give a better error
+  message about missing genetic map.
+
 
 ## qtl2 0.22-11 (2020-07-09)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2 0.23-10 (2020-12-03)
+## qtl2 0.23-11 (2020-12-08)
 
 ### Major changes
 
@@ -21,6 +21,9 @@
 - Making the tests of the plot functions only run locally, as they are
   failing on R-devel and it seems like it could be a pain running
   these on CRAN.
+
+- Make the [vdiffr](https://vdiffr.r-lib.org) package optional: only
+  test the plots locally, and only if vdiffr is installed.
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,10 +18,6 @@
 
 - Implemented Issue #184, to make `calc_het()` multi-core.
 
-- Making the tests of the plot functions only run locally, as they are
-  failing on R-devel and it seems like it could be a pain running
-  these on CRAN.
-
 - Make the [vdiffr](https://vdiffr.r-lib.org) package optional: only
   test the plots locally, and only if vdiffr is installed.
 

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -74,10 +74,11 @@ function(cross, map=NULL, error_prob=1e-4,
     if(!is_nonneg_number(error_prob)) stop("error_prob should be a single non-negative number")
     map_function <- match.arg(map_function)
 
-    if(!lowmem) # use other version
+    if(!lowmem) { # use other version
         return(calc_genoprob2(cross=cross, map=map,
                               error_prob=error_prob, map_function=map_function,
                               quiet=quiet, cores=cores))
+    }
 
     # set up cluster; set quiet=TRUE if multi-core
     cores <- setup_cluster(cores, quiet)
@@ -87,8 +88,10 @@ function(cross, map=NULL, error_prob=1e-4,
     }
 
     # pseudomarker map
-    if(is.null(map))
+    if(is.null(map)) {
+        if(is.null(cross$gmap)) stop("If cross does not contain a genetic map, map must be provided.")
         map <- insert_pseudomarkers(cross$gmap)
+    }
     # possibly subset the map
     if(length(map) != length(cross$geno) || !all(names(map) == names(cross$geno))) {
         chr <- names(cross$geno)

--- a/R/calc_genoprob2.R
+++ b/R/calc_genoprob2.R
@@ -23,8 +23,10 @@ function(cross, map=NULL, error_prob=1e-4,
     }
 
     # pseudomarker map
-    if(is.null(map))
+    if(is.null(map)) {
+        if(is.null(cross$gmap)) stop("If cross does not contain a genetic map, map must be provided.")
         map <- insert_pseudomarkers(cross$gmap)
+    }
     # possibly subset the map
     if(length(map) != length(cross$geno) || !all(names(map) == names(cross$geno))) {
         chr <- names(cross$geno)

--- a/R/est_herit.R
+++ b/R/est_herit.R
@@ -98,7 +98,7 @@ est_herit <-
     # find individuals in common across all arguments
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(kinshipIDs, addcovar, weights, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, pheno[rowSums(is.finite(pheno)) > 0,,drop=FALSE])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/kinship_util.R
+++ b/R/kinship_util.R
@@ -110,6 +110,7 @@ check_kinship_onechr <-
 
 # multiply kinship by weights (from and back)
 # assuming weights are really square-root weights
+#' @importFrom stats setNames
 weight_kinship <-
     function(kinship, weights=NULL, tol=1e-8)
 {
@@ -132,7 +133,7 @@ weight_kinship <-
     }
 
     # line them up
-    ind2keep <- get_common_ids(rownames(kinship), names(weights))
+    ind2keep <- get_common_ids(setNames(rownames(kinship), NULL), setNames(names(weights), NULL))
     weights <- weights[ind2keep]
     kinship <- kinship[ind2keep, ind2keep, drop=FALSE]
 

--- a/R/predict_snpgeno.R
+++ b/R/predict_snpgeno.R
@@ -16,6 +16,7 @@
 #' @keywords utilities
 #' @seealso [maxmarg()], [viterbi()], [calc_errorlod()]
 #' @export
+#' @importFrom stats setNames
 #'
 #' @examples
 #' \dontrun{
@@ -42,7 +43,7 @@ function(cross, geno, cores=1)
    # ensure same chromosomes
    if(n_chr(cross) != length(geno) ||
       any(chr_names(cross) != names(geno))) {
-       chr <- get_common_ids(chr_names(cross), names(geno))
+       chr <- get_common_ids(setNames(chr_names(cross), NULL), setNames(names(geno), NULL))
        cross <- cross[,chr]
        geno <- geno[,chr]
    }
@@ -50,7 +51,7 @@ function(cross, geno, cores=1)
    # ensure same individuals
    if(n_ind_geno(cross) != nrow(geno[[1]]) ||
       any(ind_ids_geno(cross) != rownames(geno[[1]]))) {
-       ind <- get_common_ids(ind_ids_geno(cross), rownames(geno[[1]]))
+       ind <- get_common_ids(setNames(ind_ids_geno(cross), NULL), setNames(rownames(geno[[1]]), NULL))
        cross <- cross[ind,]
        geno <- geno[ind,]
    }
@@ -75,7 +76,7 @@ function(cross, geno, cores=1)
        ph2 <- ph[[chr]][,,2]
        if(ncol(fg) != ncol(ph1) ||
           any(colnames(fg) != colnames(ph1))) {
-           mar <- get_common_ids(colnames(fg), colnames(ph1))
+           mar <- get_common_ids(setNames(colnames(fg), NULL), setNames(colnames(ph1), NULL))
            fg <- fg[,mar,drop=FALSE]
            ph1 <- ph1[,mar,drop=FALSE]
            ph2 <- ph2[,mar,drop=FALSE]

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -249,11 +249,19 @@ function(file, quiet=TRUE)
     if("alleles" %in% names(control)) {
         output$alleles <- control$alleles
         used_control["alleles"] <- TRUE # indicate that we used it
-        if(n_alleles != length(output$alleles))
-            stop("length(alleles) [", length(output$alleles),
-                 "] != expected number [", n_alleles, "]")
+        if(n_alleles != length(output$alleles)) {
+            if(length(output$alleles) < n_alleles) {
+                # pad with a bunch of letters
+                output$alleles <- c(output$alleles,
+                                    rep(LETTERS[!(LETTERS %in% output$alleles)], n_alleles))
+            }
+            # trim to n_alleles
+            output$alleles <- output$alleles[seq_len(n_alleles)]
+            warning("length(alleles) [", length(output$alleles),
+                    "] != expected number [", n_alleles, "]")
+        }
     } else {
-        output$alleles <- LETTERS[1:n_alleles]
+        output$alleles <- LETTERS[seq_len(n_alleles)]
     }
 
     class(output) <- "cross2"

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -210,7 +210,7 @@ scan1 <-
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, addcovar, Xcovar, intcovar,
                                weights, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, pheno[rowSums(is.finite(pheno)) > 0,,drop=FALSE])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/scan1_pg.R
+++ b/R/scan1_pg.R
@@ -55,7 +55,7 @@ scan1_pg <-
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, addcovar, Xcovar, intcovar,
                                kinshipIDs, weights, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, pheno[rowSums(is.finite(pheno)) > 0,,drop=FALSE])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/scan1max.R
+++ b/R/scan1max.R
@@ -147,7 +147,7 @@ scan1max <-
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, addcovar, Xcovar, intcovar,
                                weights, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, pheno[rowSums(is.finite(pheno)) > 0,,drop=FALSE])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/scan1max_pg.R
+++ b/R/scan1max_pg.R
@@ -55,7 +55,7 @@ scan1max_pg <-
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, addcovar, Xcovar, intcovar,
                                kinshipIDs, weights, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, pheno[rowSums(is.finite(pheno)) > 0,,drop=FALSE])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/scan1perm.R
+++ b/R/scan1perm.R
@@ -223,7 +223,7 @@ scan1perm <-
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, addcovar, Xcovar, intcovar,
                                kinshipIDs, weights, perm_strata, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, pheno[rowSums(is.finite(pheno)) > 0,,drop=FALSE])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/weights_util.R
+++ b/R/weights_util.R
@@ -36,18 +36,20 @@ sqrt_weights <-
 
 
 # multiply a vector by a set of weights
+#' @importFrom stats setNames
 weight_vector <-
     function(vec, weights, tol=1e-12)
 {
     if(is_null_weights(weights, tol) || is.null(vec)) return(vec)
 
     # align and multiply
-    id <- get_common_ids(names(vec), names(weights))
+    id <- get_common_ids(setNames(names(vec), NULL), setNames(names(weights), NULL))
     vec[id] * weights[id]
 }
 
 
 # multiply a matrix by a set of weights
+#' @importFrom stats setNames
 weight_matrix <-
     function(mat, weights, tol=1e-12)
 {
@@ -57,11 +59,12 @@ weight_matrix <-
     if(!is.matrix(mat)) mat <- as.matrix(mat)
 
     # align and multiply
-    id <- get_common_ids(rownames(mat), names(weights))
+    id <- get_common_ids(setNames(rownames(mat), NULL), setNames(names(weights), NULL))
     mat[id,,drop=FALSE] * weights[id]
 }
 
 # multiply an array by a set of weights
+#' @importFrom stats setNames
 weight_array <-
     function(arr, weights, tol=1e-12)
 {
@@ -72,6 +75,6 @@ weight_array <-
         stop("arr should be a 3-dimensional array")
 
     # align and multiply
-    id <- get_common_ids(rownames(arr), names(weights))
+    id <- get_common_ids(setNames(rownames(arr), NULL), setNames(names(weights), NULL))
     arr[id,,,drop=FALSE] * weights[id]
 }

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -1,0 +1,5 @@
+# use vdiffr only if installed
+expect_doppelganger <- function(title, fig, path = NULL, ...) {
+  testthat::skip_if_not_installed("vdiffr")
+  vdiffr::expect_doppelganger(title, fig, path = path, ...)
+}

--- a/tests/testthat/test-plot_coef.R
+++ b/tests/testthat/test-plot_coef.R
@@ -16,6 +16,6 @@ test_that("plot_coef works", {
 
     test_plot_coef <- function() plot(coef, map, columns=1:3)
 
-    vdiffr::expect_doppelganger("plot_coef", test_plot_coef)
+    expect_doppelganger("plot_coef", test_plot_coef)
 
 })

--- a/tests/testthat/test-plot_genes.R
+++ b/tests/testthat/test-plot_genes.R
@@ -16,6 +16,6 @@ test_that("plot_genes works", {
 
     test_plot_genes <- function() plot_genes(genes, xlim=c(140, 146), scale=1e-6)
 
-    vdiffr::expect_doppelganger("plot_genes", test_plot_genes)
+    expect_doppelganger("plot_genes", test_plot_genes)
 
 })

--- a/tests/testthat/test-plot_genoprob.R
+++ b/tests/testthat/test-plot_genoprob.R
@@ -15,6 +15,6 @@ test_that("plot_genoprob works", {
         plot_genoprob(probs, map, ind="232", main="232")
     }
 
-    vdiffr::expect_doppelganger("plot_genoprob", test_plot_genoprob)
+    expect_doppelganger("plot_genoprob", test_plot_genoprob)
 
 })

--- a/tests/testthat/test-plot_peaks.R
+++ b/tests/testthat/test-plot_peaks.R
@@ -19,10 +19,10 @@ test_that("plot_peaks works", {
 
     test_plot_peaks <- function() plot_peaks(peaks, map)
 
-    vdiffr::expect_doppelganger("plot_peaks", test_plot_peaks)
+    expect_doppelganger("plot_peaks", test_plot_peaks)
 
     peaks <- find_peaks(out, map, threshold=3.5)
     test_plot_peaks_noci <- function() plot_peaks(peaks, map)
-    vdiffr::expect_doppelganger("plot_peaks_noci", test_plot_peaks_noci)
+    expect_doppelganger("plot_peaks_noci", test_plot_peaks_noci)
 
 })

--- a/tests/testthat/test-plot_pxg.R
+++ b/tests/testthat/test-plot_pxg.R
@@ -11,9 +11,9 @@ test_that("plot_pxg works", {
     geno <- maxmarg(probs, map, chr=16, pos=28.6, return_char=TRUE)
 
     test_plot_pxg <- function() plot_pxg(geno, log10(iron$pheno[,1]), ylab="log liver")
-    vdiffr::expect_doppelganger("plot_pxg", test_plot_pxg)
+    expect_doppelganger("plot_pxg", test_plot_pxg)
 
     test_plot_pxg_se <- function() plot_pxg(geno, log10(iron$pheno[,1]), ylab="log liver", SEmult=2)
-    vdiffr::expect_doppelganger("plot_pxg_se", test_plot_pxg_se)
+    expect_doppelganger("plot_pxg_se", test_plot_pxg_se)
 
 })

--- a/tests/testthat/test-plot_scan1.R
+++ b/tests/testthat/test-plot_scan1.R
@@ -22,11 +22,11 @@ test_that("plot_scan1 works", {
         legend("topleft", lwd=2, col=c("darkslateblue", "violetred"), colnames(out),
                bg="gray90") }
 
-    vdiffr::expect_doppelganger("plot_scan1", test_plot_scan1)
+    expect_doppelganger("plot_scan1", test_plot_scan1)
 
 
     # single chromosome
     test_plot_scan1_onechr <- function() plot(out, map, chr=2)
-    vdiffr::expect_doppelganger("plot_scan1_onechr", test_plot_scan1_onechr)
+    expect_doppelganger("plot_scan1_onechr", test_plot_scan1_onechr)
 
 })

--- a/tests/testthat/test-scan1.R
+++ b/tests/testthat/test-scan1.R
@@ -664,3 +664,30 @@ test_that("weights derived from table() are okay", {
     expect_equal(out1k, out2k)
 
 })
+
+test_that("scan1 can handle names in the phenotype rownames", {
+
+    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+    pr <- calc_genoprob(iron, error_prob=0.002)
+    pheno <- iron$pheno
+    out <- scan1(pr, pheno)
+
+    names(rownames(pheno)) <- paste0("mouse", rownames(pheno))
+    expect_equal(scan1(pr, pheno), out)
+
+    names(rownames(pheno)) <- rep(NA, nrow(pheno))
+    expect_equal(scan1(pr, pheno), out)
+
+
+    # the same with kinship matrix
+    pheno <- iron$pheno
+    k <- calc_kinship(pr)
+    out <- scan1(pr, pheno, k)  # no error
+
+    names(rownames(pheno)) <- paste0("mouse", rownames(pheno))
+    expect_equal(scan1(pr, pheno, k), out)
+
+    names(rownames(pheno)) <- rep(NA, nrow(pheno))
+    expect_equal(scan1(pr, pheno, k), out)
+
+})


### PR DESCRIPTION
- Make the use of vdiffr in tests conditional on it being installed
- Fix Issue #157, to have `calc_genoprob()` give better errors re missing genetic map
- Fix Issue #178, to have `read_cross2()` give a warning rather than error re no. alleles
- Fix Issue #180 re `scan1()` giving error if phenotype rownames have names
- .Rbuildignore: avoid `.RData` files in subdirectories