### PR TITLE
use multiple cores in scan1_pg.R routine scan1_pg_clean

### DIFF
--- a/R/scan1_pg.R
+++ b/R/scan1_pg.R
@@ -316,38 +316,44 @@ scan1_pg_clean <-
 
     # This creates a batch for every chr, pheno and set of positions.
     # If cores == 1, use all positions on each chr (original code).
-    # if cores > 1, then
-    #    if length(npos_by_chr) > 1 (multiple chr)
-    #       1) same as cores == 1 (overrides second option for now)
-    #       2) separate batch by pos (not ideal, but coded below)
-    #       3) divide positions across chr into cores regions (not coded yet) 
-    #    if length(npos_by_chr) == 1 (one chr)
-    #       divide positions into cores regions
+    # if cores != 1, then
+    #   for each chr, divide positions into contiguous intervals
+    #   number of intervals across chr and phenos =~ cores
     npos_by_chr <- dim(genoprobs)[3,]
-    if(cores == 1 | length(npos_by_chr) > 1) {
+    # Genoprob names not retained for qtl2fst
+    names(npos_by_chr) <- names(genoprobs)
+    if(n_cores(cores) == 1) {
+      # Add beginning and end pos of each chr to original batches list.
       batches <- list(chr=rep(seq_len(length(genoprobs)), ncol(pheno)),
                       pos1 = rep(1, length(genoprobs) * ncol(pheno)),
                       pos2 = rep(npos_by_chr, ncol(pheno)),
                       phecol=rep(seq_len(ncol(pheno)), each=length(genoprobs)))
     } else {
-      if(length(npos_by_chr) == 1) {
-        npos <- ceiling(npos_by_chr / cores)
-        pos1 <- seq(1, npos_by_chr, by = npos)
-        pos2 <- c(pos1[-1] - 1, npos_by_chr)
-        npos <- length(pos1)
-        pos1 <- rep(pos1, ncol(pheno))
-        pos2 <- rep(pos2, ncol(pheno))
-      } else {
-        npos <- npos_by_chr
-        pos1 <- rep(as.vector(unlist(sapply(npos_by_chr, seq_len))), ncol(pheno))
-        pos2 <- pos1
+      # Divide each chr into intervals pos1:pos2 contiguous from 1 to length of chr.
+      tmpfn <- function(x) {
+        npos <- ceiling(x * ncol(pheno) * length(npos_by_chr) / n_cores(cores))
+        pos1 <- seq(1, x, by = npos)
+        pos2 <- c(pos1[-1] - 1, x)
+        list(pos1 = pos1, pos2 = pos2)
       }
-      batches <- list(chr=rep(rep(seq_len(length(genoprobs)), npos), ncol(pheno)),
-                      pos1=pos1,
-                      pos2=pos2,
+      npos <- lapply(npos_by_chr, tmpfn)
+      
+      # Collapse pos1 and pos2 into vectors.
+      pos1 <- pos2 <- NULL
+      for(i in names(npos)) {
+        pos1 <- c(pos1, npos[[i]]$pos1)
+        pos2 <- c(pos2, npos[[i]]$pos2)
+      }
+      # npos = number of intervals by chr
+      npos <- sapply(npos, function(x) length(x$pos1))
+      
+      # Batches list
+      batches <- list(chr=rep(rep(seq_len(length(genoprobs)),npos), ncol(pheno)),
+                      pos1=rep(pos1, ncol(pheno)),
+                      pos2=rep(pos2, ncol(pheno)),
                       phecol=rep(seq_len(ncol(pheno)), each=sum(npos)))
     }
-
+    
     # function that does the work
     by_batch_func <-
         function(batch)


### PR DESCRIPTION
Karl,
I added code to scan1_pg_clean somewaht similar to what you did for scan1perm_pg but now over (possibly multiple) chr and pheno. Below are comments. Changes start at line 317 through 388 in branch **byandell**. Perhaps you can try it out and decide if you like it. Brian 

    # This creates a batch for every chr, pheno and set of positions.
    # If cores == 1, use all positions on each chr (original code).
    # if cores != 1, then
    #   for each chr, divide positions into contiguous intervals
    #   number of intervals across chr and phenos =~ cores
